### PR TITLE
Fix twitter share link

### DIFF
--- a/web/components/Share.vue
+++ b/web/components/Share.vue
@@ -26,7 +26,7 @@ export default {
   computed: {
     twitterUrl() {
       return (
-        "https://twitter.com/share?url=" +
+        "https://twitter.com/intent/tweet?url=" +
         encodeURIComponent(this.url) +
         "&text=" +
         encodeURIComponent(this.message) +


### PR DESCRIPTION
Android環境で、Twitterシェアボタンを押しても正しく投稿画面が開かない状態になっていました。

[こちら](https://foxism.jp/2023/05/twitter-share-button/)の通り現在Androidでは `https://twitter.com/share`の共有リンクがうまく動作しないため、正しく動作するリンクに差し替えました。

なお、`twitter.com`を`x.com`に変更することも考えましたが、現状`twitter.com`のほうが正規のURLと考えられる(`x.com`->`twitter.com`のリダイレクトがある)ため一旦保留しています。