### PR TITLE
CI: actionlint が弾く古い GitHub Actions を新バージョンへ更新

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run actionlint
         shell: bash
@@ -22,12 +22,12 @@ jobs:
           ./actionlint -color
 
       - name: setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
 
       - name: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -61,7 +61,7 @@ jobs:
         run: |
           set -ex
           echo "${{ secrets.DEV_GCLOUD_SERVICE_KEY }}" | base64 -d > ${{ env.GCP_KEY_PATH }}
-      - uses: 'google-github-actions/auth@v1'
+      - uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.DEV_GCLOUD_SERVICE_KEY }}'
 
@@ -69,7 +69,7 @@ jobs:
         run: 'gcloud auth list --filter=status:ACTIVE --format="value(account)"'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
         with:
           install_components: ''
           project_id: 'd-shrine-dev'

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run actionlint
         shell: bash
@@ -22,12 +22,12 @@ jobs:
           ./actionlint -color
 
       - name: setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
 
       - name: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -64,14 +64,14 @@ jobs:
         run: |
           set -ex
           echo "${{ secrets.PROD_GCLOUD_SERVICE_KEY }}" | base64 -d > ${{ env.GCP_KEY_PATH }}
-      - uses: 'google-github-actions/auth@v1'
+      - uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.PROD_GCLOUD_SERVICE_KEY }}'
       - name: 'Use gcloud CLI'
         run: 'gcloud auth list --filter=status:ACTIVE --format="value(account)"'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
         with:
           install_components: ''
           project_id: 'd-shrine'

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -10,7 +10,7 @@ jobs:
   actions-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run actionlint
         shell: bash
@@ -22,15 +22,15 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
 
       - name: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`actions-test` ジョブ（`actionlint`）が `the runner of "..." action is too old to run on GitHub Actions` を検出して失敗していた問題を修正します。

これは `alpha-0.2` に**もともと存在する CI 失敗**で、参拝高速化/ログイン修正（PR #113）とは独立した別件のため、本PRで分離して対応します。

## 原因

GitHub Actions 側でランタイムが廃止された古いアクションバージョンを使用していたため、`actionlint` がエラーを返していた。

## 変更内容

`setup.yml` / `dev-deploy.yml` / `prod-deploy.yml` のアクションを、入力仕様が互換な最新メジャーへ更新：

| アクション | 変更 |
|-----------|------|
| `actions/checkout` | `v3` → `v4` |
| `actions/setup-node` | `v2`,`v3` → `v4` |
| `actions/cache` | `v3` → `v4` |
| `google-github-actions/auth` | `v1` → `v2` |
| `google-github-actions/setup-gcloud` | `v1` → `v2` |

いずれも入力（`node-version` / `path` / `key` / `credentials_json` / `project_id` 等）は互換のため、ワークフローの挙動は変えていません。

## 検証

- ローカルで CI と同一の `actionlint v1.7.12` を実行し、**エラーなし（exit 0）** を確認。

## 補足

- このPRを `alpha-0.2` にマージすると、PR #113 も同ベースを取り込むことで `actions-test` が通るようになります（#113 はワークフローに未変更）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

