### PR TITLE
fix: 参拝時の exp 二重加算を修正

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run actionlint
         shell: bash
@@ -22,12 +22,12 @@ jobs:
           ./actionlint -color
 
       - name: setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
 
       - name: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -61,7 +61,7 @@ jobs:
         run: |
           set -ex
           echo "${{ secrets.DEV_GCLOUD_SERVICE_KEY }}" | base64 -d > ${{ env.GCP_KEY_PATH }}
-      - uses: 'google-github-actions/auth@v1'
+      - uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.DEV_GCLOUD_SERVICE_KEY }}'
 
@@ -69,7 +69,7 @@ jobs:
         run: 'gcloud auth list --filter=status:ACTIVE --format="value(account)"'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
         with:
           install_components: ''
           project_id: 'd-shrine-dev'

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run actionlint
         shell: bash
@@ -22,12 +22,12 @@ jobs:
           ./actionlint -color
 
       - name: setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
 
       - name: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -64,14 +64,14 @@ jobs:
         run: |
           set -ex
           echo "${{ secrets.PROD_GCLOUD_SERVICE_KEY }}" | base64 -d > ${{ env.GCP_KEY_PATH }}
-      - uses: 'google-github-actions/auth@v1'
+      - uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.PROD_GCLOUD_SERVICE_KEY }}'
       - name: 'Use gcloud CLI'
         run: 'gcloud auth list --filter=status:ACTIVE --format="value(account)"'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
         with:
           install_components: ''
           project_id: 'd-shrine'

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -10,7 +10,7 @@ jobs:
   actions-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run actionlint
         shell: bash
@@ -22,15 +22,15 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
 
       - name: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/app/functions/index.js
+++ b/app/functions/index.js
@@ -995,10 +995,10 @@ exports.sanpai = functions.https.onRequest(async(request, response) => {
         msg = "2022/1/1〜2022/1/3はポイント3倍！"
       }
 
-      // 更新
+      // 参拝可能時間のロックのため last_sanpai を先に確定させる
+      // (exp/status は計算後の下の update でまとめて反映する)
       await userRef.update({
-        last_sanpai: FieldValue.serverTimestamp(),
-        exp: FieldValue.increment(add_exp)
+        last_sanpai: FieldValue.serverTimestamp()
       })
       const sanpai_logsRef = userRef.collection("sanpai_logs")
       const sanpaiRes = await sanpai_logsRef.add({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

PR #113 のレビューで指摘した**既存バグ**（参拝時に経験値 `exp` が2倍加算される）を修正します。参拝高速化/ログイン修正（#113）とは独立した別件のため、本PRで分離して対応します。

## 原因

`exports.sanpai`（`app/functions/index.js`）で `userRef.update` を2回呼んでおり、**双方に `exp: FieldValue.increment(add_exp)` が含まれていた**ため、DB上の `exp` フィールドが獲得ポイントの **2倍** 加算されていた。

```js
// 1回目
await userRef.update({ last_sanpai: serverTimestamp(), exp: FieldValue.increment(add_exp) })
...
// 2回目（ここでも increment → 合計 2*add_exp）
await userRef.update({ last_sanpai: serverTimestamp(), exp: FieldValue.increment(add_exp), status })
```

一方、レスポンス/表示用の `status.exp`（=`userData.exp + add_exp`）は1倍で計算されており、**DBの値と表示値が乖離**していた。

## 変更内容

1回目の `update` は「参拝可能時間のロックのため `last_sanpai` を先に確定させる」のが目的なので、**`exp` の加算のみを除去**。計算後の2回目の `update` でのみ1回だけ加算するようにした（`last_sanpai` の早期確定は維持）。

## 影響・注意

- 今後の参拝では `exp` が正しく1倍で加算される（`status.exp` とDBが一致）。
- **既存ユーザーの `exp` は過去の二重加算分を含む可能性がある**が、本修正は今後の加算のみを正すもので、過去データの遡及補正は行わない（データ補正が必要な場合は別途マイグレーションを提案します）。

## 補足

- `actions-test`（actionlint）を通すため、`alpha-0.2` 既存の古いアクション更新コミットを含む（#113/#114 と同一の変更）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

