### PR TITLE
fix(ci): デプロイ実行用 Node を 24 にして firebase deploy の Premature close を回避

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: cache
         uses: actions/cache@v4

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: cache
         uses: actions/cache@v4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

`env/dev` への Node 22 ランタイム反映時、`firebase deploy` の関数更新が反映されない問題が発生していました。CI ステップは success（exit 0）にもかかわらず、Firebase 側の関数は古いまま（2024/02/02 のリリース）でした。

## 根本原因（`--debug` ログで特定）

関数更新 PATCH が次の 400 で失敗していました。

```
{"error":{"code":400,
 "message":"An operation on function <name> ... is already in progress. Please try again later.",
 "status":"FAILED_PRECONDITION"}}
```

加えて、ほぼ全ての Google API 呼び出しで次が発生していました。

```
*** [apiv2] retrying https://...googleapis.com/... without keep-alive after a premature close error
```

### 因果関係
1. firebase-tools が関数更新 PATCH を keep-alive 接続で送信
2. **Node 22.23.0 / 24.17.0 のセキュリティ更新で入った keep-alive ソケット再利用のリグレッション**（[nodejs/node#63989](https://github.com/nodejs/node/issues/63989)）で「Premature close」が発生
3. apiv2 が keep-alive 無しでリトライ（[firebase-tools#10697](https://github.com/firebase/firebase-tools/pull/10697)）
4. しかし初回 PATCH は**サーバ側では成功してオペレーション開始済み**のため、リトライが `FAILED_PRECONDITION: already in progress` で弾かれ「failed to update」になる

CI ランナーを `setup-node: "22"`（=最新の 22.23.0+、リグレッション入り）にしていたことが引き金でした。歴史的に Node 18 ランナーで動いていたのは、Node 18 が EOL でこのセキュリティ更新を受けていない（=リグレッションが無い）ためです。

## 変更内容

`dev-deploy.yml` / `prod-deploy.yml` の `setup-node` を `"22"` → `"24"` に変更。firebase 公式がリグレッション修正済みとする **v24.18 以降**で firebase-tools を実行します。

- functions ランタイムは引き続き **nodejs22**（`engines.node=22`、Cloud Build がサーバ側でビルド）。CI ランナーの Node はあくまで firebase-tools の実行ホストであり、デプロイ対象ランタイムとは独立。

## 検証（Node 24.18.0 ローカル実証）
- `canvas@3.2.3` の `npm install` 成功（prebuilt が Node 24 で動作）／`createCanvas`・`toBuffer` 動作OK
- `index.js` の読み込み成功（`require('canvas')` / `chartjs-node-canvas` を含むトリガ探索が通る）
- `package-lock.json` に差分なし

> デプロイの最終確認は `env/dev` 反映時に行います（実 `firebase deploy` の成否）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

