### PR TITLE
fix(ci): デプロイ Node を 24.18.0 に固定して keep-alive リグレッションを回避

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: "24.18.0"
 
       - name: cache
         uses: actions/cache@v4

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: "24.18.0"
 
       - name: cache
         uses: actions/cache@v4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

PR #117 で `setup-node` を `"24"` に上げましたが、`env/dev` のデプロイで `firebase deploy` の関数更新が依然 1 回につき 1 関数しか進まず「failed to update」が続いていました。

## 原因

実行ログを確認したところ、ランナーは **Node v24.17.0** を使用していました。

```
node-version: 24
Found in cache @ /opt/hostedtoolcache/node/24.17.0/x64
node: v24.17.0
```

**24.17.0 は keep-alive ソケット再利用リグレッションが入っているバージョン**で、修正は **24.18.0 以降**です（[firebase-tools の対応](https://github.com/firebase/firebase-tools/commit/2ad25cf98fce2e971d0e5980d536fff784f4f0dc) 参照）。`setup-node: "24"` がランナーのツールキャッシュにある 24.17.0 を選んでしまい、修正版が取得されていませんでした。

結果として `--debug` で確認済みの次の連鎖が解消していませんでした。

```
Premature close → keep-alive 無しでリトライ → 関数更新 PATCH が
FAILED_PRECONDITION: operation already in progress
```

## 変更内容

`dev-deploy.yml` / `prod-deploy.yml` の `setup-node` を `"24"` → **`"24.18.0"`** に固定。キャッシュ済みの旧版（24.17.0）が選ばれないよう、firebase 公式が根本修正済みとする最小版を明示指定します。

## 検証
- `canvas@3.2.3` の `npm install` / 描画、`index.js` 読み込みが **Node 24.18.0** で問題ないことをローカル検証済み（PR #117 と同条件）
- functions ランタイムは引き続き **nodejs22**

> デプロイの最終確認（全関数が nodejs22 に更新され、`failed to update` が出ないこと）は `env/dev` 反映時に行います。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

