### PR TITLE
fix(ci): firebase deploy に --force を付与してクリーンアップポリシーを自動設定

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -76,5 +76,5 @@ jobs:
 
       - name: firebase deploy
         run: |
-          firebase deploy --project d-shrine-dev
+          firebase deploy --project d-shrine-dev --force
         working-directory: ./app

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -78,5 +78,5 @@ jobs:
 
       - name: firebase deploy
         run: |
-          firebase deploy --project d-shrine
+          firebase deploy --project d-shrine --force
         working-directory: ./app


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Node 24.18.0 への固定（#118）で `firebase deploy` の Premature close 問題が解消し、全関数の nodejs22 デプロイは成功するようになりました。しかし最後に次のエラーで CI が exit 1 になっていました。

```
Error: Functions successfully deployed but could not set up cleanup policy
in location us-central1. Pass the --force option to automatically set up a
cleanup policy or run 'firebase functions:artifacts:setpolicy' ...
```

関数のデプロイ自体は成功（"Functions successfully deployed"）していますが、Firebase の新仕様で関数ビルドの Docker イメージ（Artifact Registry）のクリーンアップポリシー設定が、非対話の CI 環境では確定できないためです。

## 変更内容

`dev-deploy.yml` / `prod-deploy.yml` の `firebase deploy` に `--force` を付与。firebase 公式の案内どおり、クリーンアップポリシー設定を自動承認し、非対話 CI でもデプロイが正常終了するようにします。

- `dev-deploy.yml`: `firebase deploy --project d-shrine-dev --force`
- `prod-deploy.yml`: `firebase deploy --project d-shrine --force`

> 補足: `--force` は確認プロンプトを自動承認するため、将来ソースから関数を削除した場合の削除確認もスキップされます（CI デプロイの一般的な運用）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

