### PR TITLE
参拝結果の表示拡充: 変化のカウントアップ／レベルアップ演出／SNSコピー

### DIFF
--- a/app/functions/index.js
+++ b/app/functions/index.js
@@ -11,6 +11,7 @@ const cors = require("cors")({
   origin: true
 })
 const {
+  get_level,
   user_performance,
   user_formatted_performance,
   raw_user_data_from_status,
@@ -938,13 +939,35 @@ exports.sanpai = functions.https.onRequest(async(request, response) => {
         status: userStatusData,
         last_activity_created_at: last_activity_created_at
       })
+
+      // 参拝による変化(before/after)を算出してフロントの変化表示に渡す
+      const power_before = userData.status ? userData.status.total : 0
+      const points_before = userData.exp ? userData.exp : 0
+      const level_before = get_level(power_before)
+      // 今回の参拝で更新したリポジトリ数とステップ(コミット)数
+      const updated_repo_count = new Set(
+        splited_items.map(item => item.repo && item.repo.name).filter(Boolean)
+      ).size
+      const commit_count = splited_items.reduce((sum, item) => {
+        const size = (item.type === "PushEvent" && item.payload) ? item.payload.size : 0
+        return sum + (typeof size === "number" ? size : 0)
+      }, 0)
+
       let return_data = {
         status: "success",
         add_exp: add_exp,
         level: userStatusData.level,
         exp: userStatusData.points,
         next_exp: userStatusData.next_exp,
-        msg: msg
+        msg: msg,
+        points_before: points_before,
+        points_after: userStatusData.points,
+        power_before: power_before,
+        power_after: userStatusData.total,
+        level_before: level_before,
+        level_after: userStatusData.level,
+        updated_repo_count: updated_repo_count,
+        commit_count: commit_count
       }
       if(splited_items.length == 0) {
         // アクティビティがないっぽい

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -22,6 +22,18 @@ GitHubのアクティビティを取得して更新
 ユーザー自身のページ  
 称号などユーザーが編集するデータとか?
 
+## `sanpai` レスポンスの変化情報
+
+参拝結果画面で「変化」を表示するため、`sanpai` 成功時のレスポンスに以下を含める。
+
+- `points_before` / `points_after` … ポイント(経験値)の参拝前後
+- `power_before` / `power_after` … 戦闘力(status.total)の参拝前後
+- `level_before` / `level_after` … レベルの参拝前後(いずれも戦闘力から `get_level` で算出)
+- `updated_repo_count` … 今回の参拝で更新したリポジトリ数(新着アクティビティの distinct repo)
+- `commit_count` … 今回のステップ(コミット)数(新着 PushEvent の `payload.size` 合計)
+
+`expire` / `noaction` 時はこれらの変化情報は含まない。
+
 ## 能力解析キャッシュ (`userData.status`)
 
 マイページ／プロフィール表示は `status` エンドポイントを呼ぶ。解析結果は

--- a/web/components/CountUp.vue
+++ b/web/components/CountUp.vue
@@ -1,0 +1,69 @@
+<template>
+  <span>{{ prefix }}{{ displayText }}{{ suffix }}</span>
+</template>
+
+<script>
+// 数値を from から value までアニメーションで増加表示する汎用コンポーネント。
+// 参拝結果のポイント・戦闘力など、複数箇所で再利用する。
+export default {
+  props: {
+    value: { type: Number, default: 0 },
+    from: { type: Number, default: 0 },
+    duration: { type: Number, default: 1200 },
+    delay: { type: Number, default: 0 },
+    prefix: { type: String, default: "" },
+    suffix: { type: String, default: "" },
+  },
+  data() {
+    return {
+      current: this.from,
+      rafId: null,
+      timerId: null,
+    };
+  },
+  computed: {
+    displayText() {
+      return this.current.toLocaleString();
+    },
+  },
+  mounted() {
+    this.start(this.from, this.value);
+  },
+  watch: {
+    value(newVal) {
+      this.start(this.current, newVal);
+    },
+  },
+  beforeDestroy() {
+    this.stop();
+  },
+  methods: {
+    stop() {
+      if (this.rafId) cancelAnimationFrame(this.rafId);
+      if (this.timerId) clearTimeout(this.timerId);
+      this.rafId = null;
+      this.timerId = null;
+    },
+    start(start, end) {
+      this.stop();
+      this.current = start;
+      this.timerId = setTimeout(() => {
+        const startTime = performance.now();
+        const diff = end - start;
+        const tick = (now) => {
+          const progress = Math.min((now - startTime) / this.duration, 1);
+          // easeOutCubic でゆっくり止まる
+          const eased = 1 - Math.pow(1 - progress, 3);
+          this.current = Math.round(start + diff * eased);
+          if (progress < 1) {
+            this.rafId = requestAnimationFrame(tick);
+          } else {
+            this.current = end;
+          }
+        };
+        this.rafId = requestAnimationFrame(tick);
+      }, this.delay);
+    },
+  },
+};
+</script>

--- a/web/components/LevelUpBanner.vue
+++ b/web/components/LevelUpBanner.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="levelup">
+    <div class="levelup-glow"></div>
+    <div class="levelup-body">
+      <div class="levelup-title">LEVEL UP!</div>
+      <div class="levelup-levels">
+        <span class="levelup-from">Lv.{{ from }}</span>
+        <span class="levelup-arrow">▶</span>
+        <span class="levelup-to">Lv.{{ to }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+// レベルアップ時に派手に表示するバナー。レベルが上がった時だけ親で v-if 表示する。
+export default {
+  props: {
+    from: { type: Number, default: 0 },
+    to: { type: Number, default: 0 },
+  },
+};
+</script>
+
+<style scoped>
+.levelup {
+  position: relative;
+  margin: 1.5rem auto;
+  padding: 1.5rem 1rem;
+  max-width: 600px;
+  border-radius: 16px;
+  overflow: hidden;
+  background: linear-gradient(135deg, #ff9800, #ff5252, #e91e63);
+  box-shadow: 0 0 30px rgba(255, 152, 0, 0.7);
+  animation: levelup-pop 0.6s cubic-bezier(0.18, 0.89, 0.32, 1.28) both;
+}
+
+.levelup-glow {
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.55) 0%,
+    rgba(255, 255, 255, 0) 60%
+  );
+  animation: levelup-shine 2.5s linear infinite;
+  pointer-events: none;
+}
+
+.levelup-body {
+  position: relative;
+  z-index: 1;
+  color: #fff;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+}
+
+.levelup-title {
+  font-size: 2.6rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  animation: levelup-blink 0.9s ease-in-out infinite alternate;
+}
+
+.levelup-levels {
+  margin-top: 0.5rem;
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.levelup-arrow {
+  margin: 0 0.6rem;
+  color: #fff200;
+}
+
+.levelup-to {
+  font-size: 2.2rem;
+  color: #fff200;
+}
+
+@keyframes levelup-pop {
+  0% {
+    transform: scale(0.3) rotate(-6deg);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1) rotate(0deg);
+    opacity: 1;
+  }
+}
+
+@keyframes levelup-blink {
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(1.08);
+  }
+}
+
+@keyframes levelup-shine {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/web/components/README.md
+++ b/web/components/README.md
@@ -5,3 +5,16 @@
 The components directory contains your Vue.js Components.
 
 _Nuxt.js doesn't supercharge these components._
+
+## 参拝結果の演出コンポーネント
+
+`pages/sanpai.vue`（参拝結果）で使う、変化表示・演出系の再利用コンポーネント。
+
+- `CountUp.vue` … 数値を `from`→`value` までアニメーションで増加表示する汎用コンポーネント。
+  ポイント・戦闘力などに使用。props: `value` `from` `duration` `delay` `prefix` `suffix`。
+- `LevelUpBanner.vue` … レベルアップ時に派手に表示するバナー。`from`/`to` を受け取り、
+  レベルが上がった時だけ親側で `v-if` 表示する。
+- `ShareText.vue` … SNS投稿用テキストを表示し、ワンクリックでクリップボードへコピーする。
+  テキストエリアは編集可能。props: `text` `title`。
+
+`Loading.vue`（鳥居＋スピナー）が参拝の解析中アニメーションを担う。

--- a/web/components/ShareText.vue
+++ b/web/components/ShareText.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="share-text">
+    <div v-if="title" class="fs-5 mb-2">{{ title }}</div>
+    <textarea
+      class="form-control share-text-area"
+      rows="4"
+      v-model="editableText"
+    ></textarea>
+    <button
+      type="button"
+      class="btn btn-primary mt-2"
+      :class="{ copied: copied }"
+      @click="copy"
+    >
+      <i class="fas fa-copy fa-fw"></i>
+      {{ copied ? "コピーしました！" : "クリップボードにコピー" }}
+    </button>
+  </div>
+</template>
+
+<script>
+// SNS投稿用テキストを表示し、ワンクリックでクリップボードへコピーするコンポーネント。
+// テキストは編集可能にしてあるため、コピー前に手直しもできる。
+export default {
+  props: {
+    text: { type: String, default: "" },
+    title: { type: String, default: "" },
+  },
+  data() {
+    return {
+      editableText: this.text,
+      copied: false,
+      resetTimer: null,
+    };
+  },
+  watch: {
+    text(value) {
+      this.editableText = value;
+    },
+  },
+  beforeDestroy() {
+    if (this.resetTimer) clearTimeout(this.resetTimer);
+  },
+  methods: {
+    async copy() {
+      await navigator.clipboard.writeText(this.editableText);
+      this.copied = true;
+      if (this.resetTimer) clearTimeout(this.resetTimer);
+      this.resetTimer = setTimeout(() => {
+        this.copied = false;
+      }, 2000);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.share-text-area {
+  resize: vertical;
+}
+.btn.copied {
+  background-color: #2e7d32;
+  border-color: #2e7d32;
+}
+</style>

--- a/web/pages/sanpai.vue
+++ b/web/pages/sanpai.vue
@@ -12,8 +12,68 @@
         </div>
         <div class="fs-1">「殊勝なことじゃ。きっと良きことがあるぞよ。」</div>
         <div class="fs-4 mt-4">{{ status.msg }}</div>
-        <div class="fs-4 mt-4">ポイントを獲得しました</div>
-        <div class="fs-4">＋{{ status.get }} pt</div>
+
+        <LevelUpBanner
+          v-if="isLevelUp"
+          :from="status.levelBefore"
+          :to="status.levelAfter"
+        />
+
+        <!-- ポイントの変化 -->
+        <div class="result-block mt-4">
+          <div class="fs-5">獲得ポイント</div>
+          <div class="fs-2 result-line">
+            <span class="text-muted">{{ status.pointsBefore.toLocaleString() }}</span>
+            <span class="result-arrow">→</span>
+            <CountUp
+              :from="status.pointsBefore"
+              :value="status.pointsAfter"
+              :delay="300"
+              suffix=" pt"
+            />
+            <span class="badge bg-success ms-2">+{{ status.get }}</span>
+          </div>
+        </div>
+
+        <!-- 戦闘力の変化 -->
+        <div class="result-block mt-4">
+          <div class="fs-5">戦闘力</div>
+          <div class="fs-2 result-line">
+            <span class="text-muted">{{ status.powerBefore.toLocaleString() }}</span>
+            <span class="result-arrow">→</span>
+            <CountUp
+              :from="status.powerBefore"
+              :value="status.powerAfter"
+              :delay="600"
+            />
+            <span v-if="powerDelta > 0" class="badge bg-danger ms-2">
+              +{{ powerDelta }}
+            </span>
+          </div>
+        </div>
+
+        <!-- 今回の参拝でのアクティビティ差分 -->
+        <div class="result-block mt-4">
+          <div class="d-flex justify-content-center result-activity">
+            <div class="mx-3">
+              <div class="fs-6">更新リポジトリ</div>
+              <div class="fs-3">
+                <CountUp :value="status.updatedRepoCount" :delay="900" />
+              </div>
+            </div>
+            <div class="mx-3">
+              <div class="fs-6">ステップ(コミット)</div>
+              <div class="fs-3">
+                <CountUp :value="status.commitCount" :delay="900" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- SNS投稿用テキスト -->
+        <div class="my-5 mx-auto" style="max-width: 600px">
+          <ShareText title="SNSで自慢しよう" :text="shareText"></ShareText>
+        </div>
       </div>
       <div v-else-if="result === 'expire'">
         <div class="px-5">
@@ -84,6 +144,15 @@ export default {
         level: 0,
         point: 0,
         get: 0,
+        msg: "",
+        pointsBefore: 0,
+        pointsAfter: 0,
+        powerBefore: 0,
+        powerAfter: 0,
+        levelBefore: 0,
+        levelAfter: 0,
+        updatedRepoCount: 0,
+        commitCount: 0,
       },
     };
   },
@@ -117,31 +186,67 @@ export default {
         this.isLoading = false;
       })
     if (response) {
-      console.log("response",response)
-      this.status.level = response.data.level;
-      this.status.get = response.data.add_exp;
-      this.status.point = response.data.exp;
-      this.status.msg = response.data.msg;
-      this.result = response.data.status;
+      const d = response.data;
+      this.status.level = d.level;
+      this.status.get = d.add_exp;
+      this.status.point = d.exp;
+      this.status.msg = d.msg;
+      this.status.pointsBefore = d.points_before != null ? d.points_before : 0;
+      this.status.pointsAfter = d.points_after != null ? d.points_after : d.exp;
+      this.status.powerBefore = d.power_before != null ? d.power_before : 0;
+      this.status.powerAfter = d.power_after != null ? d.power_after : 0;
+      this.status.levelBefore = d.level_before != null ? d.level_before : 0;
+      this.status.levelAfter = d.level_after != null ? d.level_after : d.level;
+      this.status.updatedRepoCount = d.updated_repo_count != null ? d.updated_repo_count : 0;
+      this.status.commitCount = d.commit_count != null ? d.commit_count : 0;
+      this.result = d.status;
       this.isLoading = false;
     } else {
       this.isError = true;
       this.isLoading = false;
     }
   },
-  methods: {
-    sanpai() {
-      this.$router.push("/result/" + "0123456789");
-    },
-  },
   computed: {
     ...mapGetters(["user"]),
+    powerDelta() {
+      return this.status.powerAfter - this.status.powerBefore;
+    },
+    isLevelUp() {
+      return this.status.levelAfter > this.status.levelBefore;
+    },
     shareUrl() {
       return this.$config.baseUrl;
     },
     shareMessage() {
       return "でばっぐ神社に参拝して、" + this.status.get + "ポイント獲得しました。";
-    }
+    },
+    shareText() {
+      const lines = [
+        "⛩️でばっぐ神社に参拝しました",
+        `獲得ポイント: +${this.status.get} pt (合計 ${this.status.pointsAfter} pt)`,
+        `戦闘力: ${this.status.powerBefore} → ${this.status.powerAfter}` +
+          (this.powerDelta > 0 ? ` (+${this.powerDelta})` : ""),
+        `レベル: Lv.${this.status.levelAfter}` +
+          (this.isLevelUp ? `（${this.status.levelBefore}からレベルアップ！）` : ""),
+        `更新リポジトリ: ${this.status.updatedRepoCount} / ステップ: ${this.status.commitCount}`,
+        "#でばっぐ神社",
+        this.shareUrl,
+      ];
+      return lines.join("\n");
+    },
   },
 };
 </script>
+
+<style scoped>
+.result-arrow {
+  margin: 0 0.6rem;
+  color: #888;
+}
+.result-line {
+  font-weight: 700;
+}
+.result-activity > div {
+  min-width: 130px;
+}
+</style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

参拝結果の表示が簡素すぎたため、「変化」を可視化し演出を追加する。

## バックエンド（`app/functions/index.js`）

`sanpai` 成功レスポンスに変化情報を追加（`expire`/`noaction` 時は含めない）:

- `points_before` / `points_after` … ポイント(経験値)の前後
- `power_before` / `power_after` … 戦闘力(`status.total`)の前後
- `level_before` / `level_after` … レベルの前後（いずれも `get_level(戦闘力)` で算出し比較の一貫性を担保）
- `updated_repo_count` … 今回更新したリポジトリ数（新着アクティビティの distinct repo）
- `commit_count` … 今回のステップ(コミット)数（新着 `PushEvent` の `payload.size` 合計）

## フロントエンド（`web/`）

`pages/sanpai.vue` の結果表示を拡充し、再利用可能な leaf コンポーネントを追加:

- **CountUp.vue** … `from`→`value` のカウントアップ演出。ポイント・戦闘力に使用
- **LevelUpBanner.vue** … レベルアップ時の派手なバナー（レベルが上がった時のみ表示）
- **ShareText.vue** … SNS投稿用テキストエリア＋ワンクリックのクリップボードコピー

表示内容:
- ポイント: 参拝前 → 後（カウントアップ）＋獲得分バッジ
- 戦闘力: 参拝前 → 後（カウントアップ）＋増加分バッジ（増えた時のみ）
- 今回の更新リポジトリ数・ステップ(コミット)数
- レベルアップ時に派手なバナー
- SNS投稿用テキスト＋コピーボタン
- 解析中は既存の `Loading`（鳥居＋スピナー）アニメーションを継続使用

クリップボードは `navigator.clipboard` を直接使用（フォールバックは追加せず。テキストエリアは編集可能なので手動コピーも可能）。

## 検証

- バックエンド: `node --check` OK / `npm test` 13件パス
- フロントエンド: `yarn build` 成功（コンパイルエラーなし。`components/share-text`・`pages/sanpai` チャンク生成を確認）

## 補足
「ステップ数」はコミット数（`PushEvent` の `payload.size` 合計）として実装しています。意図が異なる場合（例: アクティビティ件数など）は調整します。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

