### PR TITLE
解析中ローディング演出のリッチ化（飽きさせないアニメ＋メッセージ巡回）

### DIFF
--- a/web/components/Loading.vue
+++ b/web/components/Loading.vue
@@ -1,19 +1,43 @@
 <template>
   <div class="outline">
-    <div class="outer">
-      <div class="inner">
-        <div class="container p-5 text-center">
-        <img
-          src="/torii.svg"
-          alt="でばっぐ神社"
-          class="w-75"
-          style="max-width: 500px"
-        />
-        <div class="loading-outline">
-          <div class="loading-icon"></div>
+    <div class="inner">
+      <div class="container p-5 text-center loading-scene">
+        <!-- 舞い上がる光の粒 -->
+        <div class="particles">
+          <span
+            v-for="(p, i) in particles"
+            :key="i"
+            class="particle"
+            :style="p"
+          ></span>
         </div>
-        <div class="fs-2 mt-4">{{ message }}</div>
+
+        <!-- ふわふわ浮く鳥居 -->
+        <div class="torii-wrap">
+          <img
+            src="/torii.svg"
+            alt="でばっぐ神社"
+            class="torii"
+            style="max-width: 420px"
+          />
         </div>
+
+        <!-- 順番に灯る提灯(進捗感) -->
+        <div class="lanterns">
+          <span
+            v-for="n in 5"
+            :key="n"
+            class="lantern"
+            :style="{ animationDelay: ((n - 1) * 0.18).toFixed(2) + 's' }"
+          ></span>
+        </div>
+
+        <!-- 巡回するメッセージ -->
+        <transition name="msg" mode="out-in">
+          <div class="fs-2 mt-4 loading-message" :key="currentMessage">
+            {{ currentMessage }}<span class="loading-dots"></span>
+          </div>
+        </transition>
       </div>
     </div>
   </div>
@@ -22,9 +46,45 @@
 <script>
 export default {
   props: {
-    message: "",
-  }
-}
+    // 単一メッセージ(後方互換)。messages 未指定時に使う。
+    message: { type: String, default: "" },
+    // 複数メッセージを渡すと一定間隔で巡回表示する。
+    messages: { type: Array, default: () => [] },
+    interval: { type: Number, default: 1600 },
+  },
+  data() {
+    return {
+      index: 0,
+      timerId: null,
+      // 位置・遅延・大きさをずらした光の粒。決定的な値で生成。
+      particles: Array.from({ length: 16 }).map((_, i) => ({
+        left: (3 + ((i * 61) % 94)) + "%",
+        width: (4 + (i % 3) * 3) + "px",
+        height: (4 + (i % 3) * 3) + "px",
+        animationDelay: ((i % 8) * 0.45).toFixed(2) + "s",
+        animationDuration: (3.5 + (i % 5) * 0.6).toFixed(1) + "s",
+      })),
+    };
+  },
+  computed: {
+    currentMessage() {
+      if (this.messages && this.messages.length > 0) {
+        return this.messages[this.index % this.messages.length];
+      }
+      return this.message;
+    },
+  },
+  mounted() {
+    if (this.messages && this.messages.length > 1) {
+      this.timerId = setInterval(() => {
+        this.index = (this.index + 1) % this.messages.length;
+      }, this.interval);
+    }
+  },
+  beforeDestroy() {
+    if (this.timerId) clearInterval(this.timerId);
+  },
+};
 </script>
 
 <style scoped>
@@ -32,12 +92,13 @@ export default {
   width: 100%;
   height: 100vh;
   transition: all 1s;
-  background-color: #444;
+  background: radial-gradient(circle at 50% 35%, #5a5050, #2b2b2b 70%);
 
   position: fixed;
   top: 0;
   left: 0;
   z-index: 9999;
+  overflow: hidden;
 }
 
 .inner {
@@ -49,37 +110,146 @@ export default {
   -webkit-transform: translateY(-50%) translateX(-50%);
 }
 
-.loading-outline {
-  display: flex;
-  height: 150px;
-  justify-content: center;
-  align-items: center;
-  margin: 0;
+.loading-scene {
+  position: relative;
 }
 
-.loading-icon {
-  box-sizing: border-box;
-  width: 15px;
-  height: 15px;
-  border-radius: 50%;
-  box-shadow:
-    0 -30px 0 #eee,     /*  上  */
-    21px -21px 0 #ddd,  /* 右上 */
-    30px 0 0 #ccc,      /*  右  */
-    21px 21px 0 #bbb,   /* 右下 */
-    0 30px 0 #aaa,      /*  下  */
-    -21px 21px 0 #999,  /* 左下 */
-    -30px 0 0 #666,     /*  左  */
-    -21px -21px 0 #000; /* 左上 */
-  animation: rotate 1s steps(8) 0s infinite;
+/* 鳥居 */
+.torii-wrap {
+  position: relative;
+  display: inline-block;
+  animation: torii-float 2.6s ease-in-out infinite;
+}
+.torii {
+  width: 75%;
+  filter: drop-shadow(0 0 14px rgba(255, 196, 120, 0.75));
+  animation: torii-glow 2.2s ease-in-out infinite alternate;
 }
 
-@keyframes rotate {
+@keyframes torii-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-14px);
+  }
+}
+@keyframes torii-glow {
   0% {
-    transform: rotate(0deg);
+    filter: drop-shadow(0 0 8px rgba(255, 196, 120, 0.5));
   }
   100% {
-    transform: rotate(360deg);
+    filter: drop-shadow(0 0 22px rgba(255, 150, 90, 0.95));
   }
+}
+
+/* 光の粒 */
+.particles {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.particle {
+  position: absolute;
+  bottom: -20px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #ffe6a8, #ff9a3c);
+  box-shadow: 0 0 8px rgba(255, 180, 90, 0.9);
+  opacity: 0;
+  animation-name: particle-rise;
+  animation-timing-function: ease-in;
+  animation-iteration-count: infinite;
+}
+
+@keyframes particle-rise {
+  0% {
+    transform: translateY(0) scale(0.6);
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  80% {
+    opacity: 0.9;
+  }
+  100% {
+    transform: translateY(-340px) scale(1.1);
+    opacity: 0;
+  }
+}
+
+/* 提灯(順に灯る) */
+.lanterns {
+  display: flex;
+  justify-content: center;
+  gap: 14px;
+  margin-top: 18px;
+}
+.lantern {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #6b5b4b;
+  animation: lantern-on 1.5s ease-in-out infinite;
+}
+
+@keyframes lantern-on {
+  0%,
+  100% {
+    background: #6b5b4b;
+    box-shadow: none;
+    transform: scale(1);
+  }
+  40% {
+    background: #ffcf6b;
+    box-shadow: 0 0 14px rgba(255, 196, 100, 0.95);
+    transform: scale(1.25);
+  }
+}
+
+/* メッセージ */
+.loading-message {
+  color: #fff;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  min-height: 2.2em;
+}
+.loading-dots::after {
+  content: "";
+  animation: dots 1.2s steps(4, end) infinite;
+}
+@keyframes dots {
+  0% {
+    content: "";
+  }
+  25% {
+    content: "・";
+  }
+  50% {
+    content: "・・";
+  }
+  75% {
+    content: "・・・";
+  }
+  100% {
+    content: "";
+  }
+}
+
+/* メッセージ切替フェード */
+.msg-enter-active,
+.msg-leave-active {
+  transition: opacity 0.35s, transform 0.35s;
+}
+.msg-enter {
+  opacity: 0;
+  transform: translateY(10px);
+}
+.msg-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
 }
 </style>

--- a/web/components/README.md
+++ b/web/components/README.md
@@ -17,4 +17,6 @@ _Nuxt.js doesn't supercharge these components._
 - `ShareText.vue` … SNS投稿用テキストを表示し、ワンクリックでクリップボードへコピーする。
   テキストエリアは編集可能。props: `text` `title`。
 
-`Loading.vue`（鳥居＋スピナー）が参拝の解析中アニメーションを担う。
+- `Loading.vue` … 解析中/読込中のフルスクリーン演出。ふわふわ浮く鳥居＋発光、
+  舞い上がる光の粒、順に灯る提灯（進捗感）で構成。props: `message`（単一）、
+  `messages`（配列を渡すと一定間隔で巡回表示。参拝の解析中に使用）、`interval`。

--- a/web/pages/sanpai.vue
+++ b/web/pages/sanpai.vue
@@ -115,7 +115,7 @@
     <nuxt-link class="btn btn-lg btn-primary" to="/dashboard">
       マイページを見る
     </nuxt-link>
-    <Loading v-if="isLoading" message="ブンセキチュウ..."></Loading>
+    <Loading v-if="isLoading" :messages="loadingMessages"></Loading>
   </div>
 </template>
 
@@ -140,6 +140,14 @@ export default {
       isLoading: true,
       isError: false,
       result: "",
+      loadingMessages: [
+        "ブンセキチュウ...",
+        "コミットをかぞえています",
+        "御神木にお伺いを立てています",
+        "バグを祓っています",
+        "戦闘力をはかっています",
+        "おみくじを準備しています",
+      ],
       status: {
         level: 0,
         point: 0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

参拝の「分析中」表示が単調で飽きるとのフィードバックを受け、`Loading.vue` を刷新。

## 変更内容（`web/components/Loading.vue`）

- ふわふわ上下に浮く鳥居＋発光（グロー）アニメーション
- 舞い上がる「光の粒」パーティクル（位置・遅延・速度をずらした16個）
- 順番に灯る提灯（5個）で進捗感を演出
- メッセージを複数渡せる `messages` 配列 prop を追加し、一定間隔でフェード巡回
  - 参拝時は「ブンセキチュウ...」「コミットをかぞえています」「御神木にお伺いを立てています」「バグを祓っています」「戦闘力をはかっています」「おみくじを準備しています」を巡回
- 単一 `message` prop は後方互換を維持（マイページ／プロフィールは従来どおり）

すべて CSS アニメーションで実装（新規アセット・ライブラリ追加なし）。

## 検証

- `yarn build` 成功（コンパイルエラーなし）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

