### PR TITLE
feat(web): Service Workerの自動更新（新版検知で自動リロード）

### DIFF
--- a/web/nuxt.config.js
+++ b/web/nuxt.config.js
@@ -59,6 +59,7 @@ export default {
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
   plugins: [
     '~/plugins/persistedstate.js',
+    '~/plugins/sw-update.client.js',
   ],
 
   // Auto import components (https://go.nuxtjs.dev/config-components)
@@ -109,6 +110,13 @@ export default {
 
   // pwa module configuration
   pwa: {
+    // 新SWを待たせず即時有効化し、開いているクライアントの制御を奪う。
+    // (プラグイン sw-update.client.js がこの切替を検知して自動リロードする)
+    workbox: {
+      skipWaiting: true,
+      clientsClaim: true,
+      cleanupOutdatedCaches: true,
+    },
     manifest: {
       name: "でばっぐ神社",
       title: "でばっぐ神社",

--- a/web/plugins/README.md
+++ b/web/plugins/README.md
@@ -5,3 +5,21 @@
 This directory contains Javascript plugins that you want to run before mounting the root Vue.js application.
 
 More information about the usage of this directory in [the documentation](https://nuxtjs.org/guide/plugins).
+
+## プラグイン一覧
+
+### `persistedstate.js`
+
+`vuex-persistedstate` を使い、Vuex ストアを `localStorage`(キー: `debug-shrine`)へ永続化する。
+
+### `sw-update.client.js`
+
+新しい Service Worker(=新デプロイ)を検知したら自動でページをリロードする
+クライアント専用プラグイン。スーパーリロードなしで更新を反映するための仕組み。
+
+- `nuxt.config.js` の `pwa.workbox` で `skipWaiting` / `clientsClaim` を有効化しているため、
+  新版 SW は見つかると即座に activate し、開いているタブの制御を奪う(`controllerchange` 発火)。
+- 本プラグインはその `controllerchange` を検知してページを自動リロードする。
+  初回インストール(以前 controller が無い状態)ではリロードしない。
+- 開いたままのタブでも新デプロイを取りこぼさないよう、タブ復帰時(`focus`)と
+  60 秒間隔で `registration.update()` を呼び新バージョンを確認する。

--- a/web/plugins/sw-update.client.js
+++ b/web/plugins/sw-update.client.js
@@ -1,0 +1,29 @@
+// 新しい Service Worker(=新デプロイ)を検知したら自動でページをリロードする。
+//
+// sw 側は skipWaiting / clientsClaim が有効なので、新版が見つかると即座に
+// activate して開いているタブの制御を奪う(controllerchange が発火する)。
+// ここではその切替を検知して自動リロードし、さらに開いたままのタブでも
+// 新デプロイを検知できるよう定期的に update() を呼ぶ。
+export default () => {
+  if (!("serviceWorker" in navigator)) return;
+
+  // プラグイン起動時点で既に SW に制御されているか。
+  // 初回インストール(制御なし→あり)ではリロード不要なため区別する。
+  const hadController = !!navigator.serviceWorker.controller;
+
+  let reloading = false;
+  navigator.serviceWorker.addEventListener("controllerchange", () => {
+    if (reloading || !hadController) return;
+    reloading = true;
+    window.location.reload();
+  });
+
+  navigator.serviceWorker.ready.then((registration) => {
+    const checkForUpdate = () => {
+      registration.update().catch(() => {});
+    };
+    // タブ復帰時と一定間隔で新バージョンを確認する
+    window.addEventListener("focus", checkForUpdate);
+    setInterval(checkForUpdate, 60 * 1000);
+  });
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

スーパーリロードしないと Service Worker(=新デプロイ)が反映されない問題を解消する。
新版 SW を検知したら**自動でページをリロード**する仕組みを追加。

## 原因

現状の生成済み `sw.js` はすでに `skipWaiting: true` / `clientsClaim: true` で「新SWは即時 activate し、開いているクライアントの制御を奪う」設定になっていた。
しかし**開いているページ自身がリロードしない**ため、新コードに切り替わらず手動のスーパーリロードが必要だった。

## 変更内容

- `web/nuxt.config.js`
  - `pwa.workbox` に `skipWaiting` / `clientsClaim` / `cleanupOutdatedCaches` を明示的に指定（デフォルト依存をやめ、自動更新の前提を固定）
  - プラグイン `~/plugins/sw-update.client.js` を登録
- `web/plugins/sw-update.client.js`（新規）
  - `controllerchange` を検知してページを自動リロード（初回インストール時はリロードしない）
  - タブ復帰時（`focus`）と 60 秒間隔で `registration.update()` を呼び、開いたままのタブでも新デプロイを検知
- `web/plugins/README.md`
  - プラグイン仕様を追記

## 動作の流れ

1. 開いたタブが定期的（または focus 時）に `registration.update()` で新 `sw.js` を確認
2. 新版を検知 → install → `skipWaiting` で即 activate → `clientsClaim` で制御奪取（`controllerchange` 発火）
3. プラグインが `controllerchange` を検知して `window.location.reload()` → 新コードに切替

## 検証

- `yarn generate` 成功（エラー0）
- 生成 `dist/sw.js` に `skipWaiting/clientsClaim/cleanupOutdatedCaches: true` を確認
- バンドルに `controllerchange`（プラグイン）が含まれることを確認

## 注意

本変更を反映する**最初の1回だけ**は、現在開いているページが旧コード（プラグイン未搭載）のため手動リロードが必要。
その後のデプロイからは自動更新が有効になる。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

