### PR TITLE
fix(web): 参拝結果画面の遷移ガタつきを解消（トランジション＋寸法予約）

### DIFF
--- a/web/pages/sanpai.vue
+++ b/web/pages/sanpai.vue
@@ -1,13 +1,16 @@
 <template>
   <div class="text-center">
     <div class="container" v-if="status">
+      <transition name="result-fade">
       <div v-if="result === 'success'">
         <div class="p-5">
           <img
             src="/sanpai/success_01.png"
             alt="でばっぐ神社"
             class="w-100"
-            style="max-width: 700px"
+            width="1500"
+            height="730"
+            style="max-width: 700px; height: auto"
           />
         </div>
         <div class="fs-1">「殊勝なことじゃ。きっと良きことがあるぞよ。」</div>
@@ -81,7 +84,9 @@
             src="/sanpai/expire_01.png"
             alt="でばっぐ神社"
             class="w-100"
-            style="max-width: 700px"
+            width="795"
+            height="723"
+            style="max-width: 700px; height: auto"
           />
         </div>
         <div class="fs-1">
@@ -95,7 +100,9 @@
             src="/sanpai/noaction_01.png"
             alt="でばっぐ神社"
             class="w-100"
-            style="max-width: 700px"
+            width="800"
+            height="749"
+            style="max-width: 700px; height: auto"
           />
         </div>
         <div class="fs-1">
@@ -103,6 +110,7 @@
         </div>
         <div class="fs-4 mt-4">追加のポイントはありませんでした</div>
       </div>
+      </transition>
     </div>
     <!-- v-if="result === 'success'" -->
     <div class="my-5">
@@ -115,7 +123,9 @@
     <nuxt-link class="btn btn-lg btn-primary" to="/dashboard">
       マイページを見る
     </nuxt-link>
-    <Loading v-if="isLoading" :messages="loadingMessages"></Loading>
+    <transition name="loading-fade">
+      <Loading v-if="isLoading" :messages="loadingMessages"></Loading>
+    </transition>
   </div>
 </template>
 
@@ -256,5 +266,26 @@ export default {
 }
 .result-activity > div {
   min-width: 130px;
+}
+
+/* 結果ブロックのフェードイン(下からふわっと) */
+.result-fade-enter-active {
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+.result-fade-enter {
+  opacity: 0;
+  transform: translateY(16px);
+}
+.result-fade-enter-to {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ローディング表示のフェードアウト */
+.loading-fade-leave-active {
+  transition: opacity 0.45s ease;
+}
+.loading-fade-leave-to {
+  opacity: 0;
 }
 </style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

参拝結果画面への遷移が「パッと切り替わり、表示要素のサイズが決まる前に表示されてガタつく」問題を解消する。

## 原因

1. ローディング→結果が瞬間的に切り替わっていた（トランジションなし）
2. 結果画像（`success_01.png` ほか）に `width`/`height` 指定がなく、画像読込が完了するまで高さが 0 → 読込後に高さが確定して**レイアウトシフト（CLS）**が発生していた

## 変更内容（`web/pages/sanpai.vue`）

- 結果画像3種に実寸の `width`/`height` を付与し、`height: auto` と併用して**読込前から表示領域の高さを予約**（レイアウトシフト防止）
  - `success_01.png`: 1500×730
  - `expire_01.png`: 795×723
  - `noaction_01.png`: 800×749
- 結果ブロックに**フェードイン**（下からふわっと）、ローディングに**フェードアウト**のトランジションを追加し、切り替わりをなめらかに

## 検証

- `yarn generate` 成功（エラー0）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

