### PR TITLE
fix(sanpai): ステップ(コミット)が常に0になる問題を修正→アクション数表示に変更

### DIFF
--- a/app/functions/index.js
+++ b/app/functions/index.js
@@ -944,14 +944,14 @@ exports.sanpai = functions.https.onRequest(async(request, response) => {
       const power_before = userData.status ? userData.status.total : 0
       const points_before = userData.exp ? userData.exp : 0
       const level_before = get_level(power_before)
-      // 今回の参拝で更新したリポジトリ数とステップ(コミット)数
+      // 今回の参拝で更新したリポジトリ数とプッシュ回数。
+      // GitHub Events API は 2025-10-07 に PushEvent payload から commits/size を
+      // 削除したため、コミット数は events からは取得できない。取得可能な
+      // PushEvent の件数(プッシュ回数)を用いる。
       const updated_repo_count = new Set(
         splited_items.map(item => item.repo && item.repo.name).filter(Boolean)
       ).size
-      const commit_count = splited_items.reduce((sum, item) => {
-        const size = (item.type === "PushEvent" && item.payload) ? item.payload.size : 0
-        return sum + (typeof size === "number" ? size : 0)
-      }, 0)
+      const push_count = splited_items.filter(item => item.type === "PushEvent").length
 
       let return_data = {
         status: "success",
@@ -967,7 +967,7 @@ exports.sanpai = functions.https.onRequest(async(request, response) => {
         level_before: level_before,
         level_after: userStatusData.level,
         updated_repo_count: updated_repo_count,
-        commit_count: commit_count
+        push_count: push_count
       }
       if(splited_items.length == 0) {
         // アクティビティがないっぽい

--- a/app/functions/index.js
+++ b/app/functions/index.js
@@ -944,14 +944,14 @@ exports.sanpai = functions.https.onRequest(async(request, response) => {
       const power_before = userData.status ? userData.status.total : 0
       const points_before = userData.exp ? userData.exp : 0
       const level_before = get_level(power_before)
-      // 今回の参拝で更新したリポジトリ数とプッシュ回数。
+      // 今回の参拝で更新したリポジトリ数とアクション数。
+      // アクション数は今回取得した新着アクティビティの総件数(ポイント算出の元と同じ)。
       // GitHub Events API は 2025-10-07 に PushEvent payload から commits/size を
-      // 削除したため、コミット数は events からは取得できない。取得可能な
-      // PushEvent の件数(プッシュ回数)を用いる。
+      // 削除しコミット数が取得できないため、event 種別を問わない件数を用いる。
       const updated_repo_count = new Set(
         splited_items.map(item => item.repo && item.repo.name).filter(Boolean)
       ).size
-      const push_count = splited_items.filter(item => item.type === "PushEvent").length
+      const action_count = splited_items.length
 
       let return_data = {
         status: "success",
@@ -967,7 +967,7 @@ exports.sanpai = functions.https.onRequest(async(request, response) => {
         level_before: level_before,
         level_after: userStatusData.level,
         updated_repo_count: updated_repo_count,
-        push_count: push_count
+        action_count: action_count
       }
       if(splited_items.length == 0) {
         // アクティビティがないっぽい

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -30,10 +30,9 @@ GitHubのアクティビティを取得して更新
 - `power_before` / `power_after` … 戦闘力(status.total)の参拝前後
 - `level_before` / `level_after` … レベルの参拝前後(いずれも戦闘力から `get_level` で算出)
 - `updated_repo_count` … 今回の参拝で更新したリポジトリ数(新着アクティビティの distinct repo)
-- `push_count` … 今回のプッシュ回数(新着 PushEvent の件数)
+- `action_count` … 今回のアクション数(新着アクティビティの総件数。ポイント算出の元と同じ)
   - GitHub Events API は 2025-10-07 に PushEvent payload から `commits` / `size` を
-    削除したため、コミット数は events から取得できない。取得可能な PushEvent の
-    件数(プッシュ回数)を返す。
+    削除しコミット数が取得できないため、event 種別を問わない新着件数を用いる。
 
 `expire` / `noaction` 時はこれらの変化情報は含まない。
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -30,7 +30,10 @@ GitHubのアクティビティを取得して更新
 - `power_before` / `power_after` … 戦闘力(status.total)の参拝前後
 - `level_before` / `level_after` … レベルの参拝前後(いずれも戦闘力から `get_level` で算出)
 - `updated_repo_count` … 今回の参拝で更新したリポジトリ数(新着アクティビティの distinct repo)
-- `commit_count` … 今回のステップ(コミット)数(新着 PushEvent の `payload.size` 合計)
+- `push_count` … 今回のプッシュ回数(新着 PushEvent の件数)
+  - GitHub Events API は 2025-10-07 に PushEvent payload から `commits` / `size` を
+    削除したため、コミット数は events から取得できない。取得可能な PushEvent の
+    件数(プッシュ回数)を返す。
 
 `expire` / `noaction` 時はこれらの変化情報は含まない。
 

--- a/web/pages/sanpai.vue
+++ b/web/pages/sanpai.vue
@@ -62,9 +62,9 @@
               </div>
             </div>
             <div class="mx-3">
-              <div class="fs-6">プッシュ</div>
+              <div class="fs-6">アクション</div>
               <div class="fs-3">
-                <CountUp :value="status.pushCount" :delay="900" />
+                <CountUp :value="status.actionCount" :delay="900" />
               </div>
             </div>
           </div>
@@ -160,7 +160,7 @@ export default {
         levelBefore: 0,
         levelAfter: 0,
         updatedRepoCount: 0,
-        pushCount: 0,
+        actionCount: 0,
       },
     };
   },
@@ -206,7 +206,7 @@ export default {
       this.status.levelBefore = d.level_before != null ? d.level_before : 0;
       this.status.levelAfter = d.level_after != null ? d.level_after : d.level;
       this.status.updatedRepoCount = d.updated_repo_count != null ? d.updated_repo_count : 0;
-      this.status.pushCount = d.push_count != null ? d.push_count : 0;
+      this.status.actionCount = d.action_count != null ? d.action_count : 0;
       this.result = d.status;
       this.isLoading = false;
     } else {
@@ -236,7 +236,7 @@ export default {
           (this.powerDelta > 0 ? ` (+${this.powerDelta})` : ""),
         `レベル: Lv.${this.status.levelAfter}` +
           (this.isLevelUp ? `（${this.status.levelBefore}からレベルアップ！）` : ""),
-        `更新リポジトリ: ${this.status.updatedRepoCount} / プッシュ: ${this.status.pushCount}`,
+        `更新リポジトリ: ${this.status.updatedRepoCount} / アクション: ${this.status.actionCount}`,
         "#でばっぐ神社",
         this.shareUrl,
       ];

--- a/web/pages/sanpai.vue
+++ b/web/pages/sanpai.vue
@@ -62,9 +62,9 @@
               </div>
             </div>
             <div class="mx-3">
-              <div class="fs-6">ステップ(コミット)</div>
+              <div class="fs-6">プッシュ</div>
               <div class="fs-3">
-                <CountUp :value="status.commitCount" :delay="900" />
+                <CountUp :value="status.pushCount" :delay="900" />
               </div>
             </div>
           </div>
@@ -160,7 +160,7 @@ export default {
         levelBefore: 0,
         levelAfter: 0,
         updatedRepoCount: 0,
-        commitCount: 0,
+        pushCount: 0,
       },
     };
   },
@@ -206,7 +206,7 @@ export default {
       this.status.levelBefore = d.level_before != null ? d.level_before : 0;
       this.status.levelAfter = d.level_after != null ? d.level_after : d.level;
       this.status.updatedRepoCount = d.updated_repo_count != null ? d.updated_repo_count : 0;
-      this.status.commitCount = d.commit_count != null ? d.commit_count : 0;
+      this.status.pushCount = d.push_count != null ? d.push_count : 0;
       this.result = d.status;
       this.isLoading = false;
     } else {
@@ -236,7 +236,7 @@ export default {
           (this.powerDelta > 0 ? ` (+${this.powerDelta})` : ""),
         `レベル: Lv.${this.status.levelAfter}` +
           (this.isLevelUp ? `（${this.status.levelBefore}からレベルアップ！）` : ""),
-        `更新リポジトリ: ${this.status.updatedRepoCount} / ステップ: ${this.status.commitCount}`,
+        `更新リポジトリ: ${this.status.updatedRepoCount} / プッシュ: ${this.status.pushCount}`,
         "#でばっぐ神社",
         this.shareUrl,
       ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

参拝結果の「ステップ(コミット)」が常に **0** になる問題を修正し、表示を**アクション数**に変更する。

## 原因（GitHub の仕様変更）

GitHub は **2025年10月7日**に Activity Events API の `PushEvent` payload から `commits` 配列と `size`（コミット数）を**削除**した（[GitHub Changelog](https://github.blog/changelog/2025-08-08-upcoming-changes-to-github-events-api-payloads/)）。

本アプリは `/users/{user}/events/public` を使っており、PushEvent payload のキーは現在 `repository_id, push_id, ref, head, before` のみ。認証付きでも `size` は返らない。
そのため `item.payload.size` が常に `undefined` となり `commit_count` が 0 になっていた。アプリ側のバグではなく GitHub 側の破壊的変更が原因。

## 対応

コミット数は events から取得不能になったため、**追加 API なしで取得できる「アクション数」**（今回取得した新着アクティビティの総件数 = `splited_items.length`、ポイント算出の元と同じ）を表示する。

> 補足: 当初は PushEvent 件数（プッシュ回数）に変更したが、event 種別を問わない「アクション数」の方が分かりやすいとの要望により変更（コミット履歴参照）。

## 変更内容

- `app/functions/index.js`
  - `commit_count`（`payload.size` 合計）→ `action_count`（新着アクティビティ総件数）
- `web/pages/sanpai.vue`
  - `commitCount` → `actionCount`、レスポンスマッピングを `action_count` に
  - 表示ラベル「ステップ(コミット)」→「アクション」、SNS共有文も同様
- `docs/backend.md`
  - 仕様変更の理由とともに `action_count` を記載

## 検証

- `node --check index.js` OK / 関数ユニットテスト 13 件パス
- `yarn generate` 成功（エラー0）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

