### PR TITLE
ci: gen2並列デプロイの dockerRepository クラッシュを根本修正（AR事前作成＋--docker-repository明示）

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -147,6 +147,20 @@ jobs:
             eventarc.googleapis.com \
             --project=d-shrine-dev
 
+      # gen2(Cloud Run)関数のイメージ格納先であるArtifact Registryリポジトリ
+      # (デフォルト名 gcf-artifacts)を事前に作成しておく(冪等)。
+      # gcloudは通常このリポジトリを遅延自動解決するが、複数のdeployを並列実行すると
+      # その解決が競合し、一部が
+      # `gcloud crashed (AttributeError): 'NoneType' object has no attribute 'dockerRepository'`
+      # でクラッシュする(並列時のみ・ランダムな一部で発生する非決定的な競合)。
+      # 事前作成し、各deployで --docker-repository を明示指定することで自動解決の競合を無くす。
+      - name: ensure Artifact Registry repo for gen2 functions
+        run: |
+          gcloud artifacts repositories describe gcf-artifacts \
+            --location=us-central1 --project=d-shrine-dev \
+            || gcloud artifacts repositories create gcf-artifacts \
+              --location=us-central1 --repository-format=docker --project=d-shrine-dev
+
       # Cloud Functions(Gen2)の --trigger-topic は Gen1と異なりPub/Subトピックを
       # 自動作成しない(存在しないトピックを指定すると
       # `Validation failed for trigger ...: Resource not found` で即失敗する)。
@@ -214,6 +228,8 @@ jobs:
         working-directory: ./app/functions-go
         run: |
           set -uo pipefail
+          # 事前作成済みのAR docker リポジトリを明示指定し、並列deploy時の自動解決競合を防ぐ。
+          DOCKER_REPO="projects/d-shrine-dev/locations/us-central1/repositories/gcf-artifacts"
           declare -a PIDS NAMES
           deploy() {
             local name="$1"; shift
@@ -224,6 +240,7 @@ jobs:
                 --gen2 \
                 --runtime=go125 \
                 --region=us-central1 \
+                --docker-repository="$DOCKER_REPO" \
                 --source=. \
                 --entry-point="$entry" \
                 "$@" ) > "/tmp/deploy-$name.log" 2>&1 &

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -119,6 +119,20 @@ jobs:
             eventarc.googleapis.com \
             --project=d-shrine
 
+      # gen2(Cloud Run)関数のイメージ格納先であるArtifact Registryリポジトリ
+      # (デフォルト名 gcf-artifacts)を事前に作成しておく(冪等)。
+      # gcloudは通常このリポジトリを遅延自動解決するが、複数のdeployを並列実行すると
+      # その解決が競合し、一部が
+      # `gcloud crashed (AttributeError): 'NoneType' object has no attribute 'dockerRepository'`
+      # でクラッシュする(並列時のみ・ランダムな一部で発生する非決定的な競合)。
+      # 事前作成し、各deployで --docker-repository を明示指定することで自動解決の競合を無くす。
+      - name: ensure Artifact Registry repo for gen2 functions
+        run: |
+          gcloud artifacts repositories describe gcf-artifacts \
+            --location=us-central1 --project=d-shrine \
+            || gcloud artifacts repositories create gcf-artifacts \
+              --location=us-central1 --repository-format=docker --project=d-shrine
+
       - name: create Pub/Sub topics for scheduled Go functions
         run: |
           for TOPIC in ranking-update-go ranking-cache-go status-cache-backfill-go scheduled-ogp-delete-go; do
@@ -169,6 +183,8 @@ jobs:
         working-directory: ./app/functions-go
         run: |
           set -uo pipefail
+          # 事前作成済みのAR docker リポジトリを明示指定し、並列deploy時の自動解決競合を防ぐ。
+          DOCKER_REPO="projects/d-shrine/locations/us-central1/repositories/gcf-artifacts"
           declare -a PIDS NAMES
           deploy() {
             local name="$1"; shift
@@ -179,6 +195,7 @@ jobs:
                 --gen2 \
                 --runtime=go125 \
                 --region=us-central1 \
+                --docker-repository="$DOCKER_REPO" \
                 --source=. \
                 --entry-point="$entry" \
                 "$@" ) > "/tmp/deploy-$name.log" 2>&1 &


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 症状
`env/dev` の dev-deploy 実行(`ac3d323`)で「deploy all Go Cloud Run functions in parallel」が失敗。10本中2本(`userOGPGo`/`scheduledOgpDeleteGo`)が同一クラッシュ:

```
ERROR: gcloud crashed (AttributeError): 'NoneType' object has no attribute 'dockerRepository'
```

直前の同一 workflow 実行(`52de97b`)では全10本成功しており、**並列時のみ・ランダムな一部・非決定的**という挙動だった。

## 根本原因
gen2(Cloud Run)関数のデプロイは、イメージ格納先の Artifact Registry docker リポジトリ(デフォルト `gcf-artifacts`)を **gcloud が遅延自動解決** する。複数の `gcloud functions deploy` を並列実行すると、この解決処理が競合してリポジトリ参照が `None` になり、`dockerRepository` 属性アクセスでクラッシュする。GCP公式ドキュメント/SO でも AR リポジトリの事前用意と `--docker-repository` 明示が推奨されている。

## 対策（根本対応・フォールバックではない）
1. `gcf-artifacts`(us-central1, docker) を **事前に冪等作成** するステップを追加。
2. 各 `gcloud functions deploy` に `--docker-repository=projects/<project>/locations/us-central1/repositories/gcf-artifacts` を **明示指定**し、自動解決の競合源そのものを除去。

`dev-deploy.yml`(project=`d-shrine-dev`) / `prod-deploy.yml`(project=`d-shrine`) 両方に適用。リトライ等の見かけ上の回避は入れていない。

## 検証
- `actionlint` 両ファイルパス。
- `main → env/dev` 反映で dev-deploy が再実行され、10本全て成功することを実地確認する。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1620-9502-7f39-ac9f-1467a2ee5520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

