### PR TITLE
ogpRewriteGo: ユーザー名のエスケープ不足によるHTML注入(XSS)とクエリ混入を修正

### DIFF
--- a/app/functions-go/ogp_rewrite.go
+++ b/app/functions-go/ogp_rewrite.go
@@ -13,9 +13,11 @@ package gofunctions
 import (
 	"context"
 	"fmt"
+	"html"
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -34,9 +36,12 @@ var userPathPattern = regexp.MustCompile(`/u/(.+)`)
 var ogpHTTPClient = &http.Client{}
 
 func ogpRewriteHandler(w http.ResponseWriter, r *http.Request) {
-	reqPath := r.URL.RequestURI()
-	log.Printf("ogpRewrite: request url: %s", reqPath)
+	log.Printf("ogpRewrite: request url: %s", r.URL.RequestURI())
 
+	// ユーザー名はパス部分のみから取り出す。RequestURI(パス+クエリ)に対して
+	// マッチさせると、共有リンク等に付くトラッキングパラメータ(?fbclid=... 等)まで
+	// ユーザー名に含まれてしまい、og:image のユーザー参照や説明文が壊れる。
+	reqPath := r.URL.Path
 	m := userPathPattern.FindStringSubmatch(reqPath)
 	if m == nil {
 		// Node版は Firebase Hosting の `/u/*` リライト経由でのみ呼ばれる前提のため
@@ -62,10 +67,13 @@ func runOgpRewrite(ctx context.Context, w http.ResponseWriter, username string) 
 	projectID := os.Getenv("OGP_PROJECT_ID")
 
 	nowUnix := time.Now().Unix()
+	// username はリクエストパス由来の外部入力なので、URLクエリ・HTML属性値の
+	// 各文脈に応じてエスケープしてから埋め込む(生のまま埋め込むと `"` や `<` で
+	// meta タグの属性を破壊してHTMLを注入できてしまう)。
 	// og:image は Go版OGP生成関数(userOGPGo)を指す。userOGPGoはWebP(1200x630)を返す。
-	ogpURL := fmt.Sprintf("https://us-central1-%s.cloudfunctions.net/userOGPGo?user=%s&t=%d", projectID, username, nowUnix)
-	description := fmt.Sprintf("これが%sの でばっぐのうりょくだ！", username)
-	title := fmt.Sprintf("%sの でばっぐのうりょく - でばっぐ神社", username)
+	ogpURL := fmt.Sprintf("https://us-central1-%s.cloudfunctions.net/userOGPGo?user=%s&t=%d", projectID, url.QueryEscape(username), nowUnix)
+	description := html.EscapeString(fmt.Sprintf("これが%sの でばっぐのうりょくだ！", username))
+	title := html.EscapeString(fmt.Sprintf("%sの でばっぐのうりょく - でばっぐ神社", username))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL, nil)
 	if err != nil {

--- a/app/functions-go/ogp_rewrite_test.go
+++ b/app/functions-go/ogp_rewrite_test.go
@@ -3,6 +3,7 @@ package gofunctions
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -120,6 +121,70 @@ func TestOgpRewrite_OgDescriptionWithoutPropertyAttribute(t *testing.T) {
 	ogDescTag := extractMetaTag(rec.Body.String(), "og:description")
 	if !strings.Contains(ogDescTag, "octocatの でばっぐのうりょくだ！") {
 		t.Errorf("og:description (no property attr) not rewritten: %q", ogDescTag)
+	}
+}
+
+// 共有リンクに付くトラッキングパラメータ(?fbclid=... 等)がユーザー名に
+// 混入しないこと(パス部分のみからユーザー名を取り出すこと)を確認する。
+func TestOgpRewrite_IgnoresQueryString(t *testing.T) {
+	var baseURL string
+	baseSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(sampleIndexHTML(baseURL)))
+	}))
+	defer baseSrv.Close()
+
+	baseURL = baseSrv.URL + "/"
+	t.Setenv("FUNC_BASE_URL", baseURL)
+	t.Setenv("OGP_PROJECT_ID", "d-shrine-dev")
+
+	req := httptest.NewRequest(http.MethodGet, "/u/octocat?fbclid=abc123", nil)
+	rec := httptest.NewRecorder()
+	ogpRewriteHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "userOGPGo?user=octocat&") {
+		t.Errorf("og:image user param should be octocat without query string; body=%s", body)
+	}
+	if strings.Contains(body, "fbclid") {
+		t.Errorf("query string leaked into rewritten HTML; body=%s", body)
+	}
+	if !strings.Contains(body, "octocatの でばっぐのうりょくだ！") {
+		t.Errorf("description not rewritten with clean username; body=%s", body)
+	}
+}
+
+// パス由来のユーザー名がHTML属性・URLへエスケープされずに埋め込まれて
+// HTML注入(XSS)にならないことを確認する。
+func TestOgpRewrite_EscapesUsername(t *testing.T) {
+	var baseURL string
+	baseSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(sampleIndexHTML(baseURL)))
+	}))
+	defer baseSrv.Close()
+
+	baseURL = baseSrv.URL + "/"
+	t.Setenv("FUNC_BASE_URL", baseURL)
+	t.Setenv("OGP_PROJECT_ID", "d-shrine-dev")
+
+	evil := `x"><script>alert(1)</script>`
+	req := httptest.NewRequest(http.MethodGet, "/u/"+url.PathEscape(evil), nil)
+	rec := httptest.NewRecorder()
+	ogpRewriteHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "<script>") {
+		t.Errorf("unescaped username injected script tag; body=%s", body)
+	}
+	if !strings.Contains(body, "user="+url.QueryEscape(evil)) {
+		t.Errorf("og:image user param should be query-escaped; body=%s", body)
 	}
 }
 


### PR DESCRIPTION
パス由来のユーザー名を、書き換え後HTMLとog:image URLへ埋め込む前にエスケープする。あわせてユーザー名はパス部分のみから取り出す(クエリ文字列を含めない)。

従来はユーザー名を meta の content 属性や og:image URL に無エスケープで埋め込んでいたため、細工した /u/ パスでHTML/スクリプト注入が可能だった。また RequestURI にマッチさせていたため ?fbclid= 等のクエリがユーザー名へ混入していた。両ケースのテストを追加。通常のユーザー名では出力は変わらない。