### PR TITLE
sanpaiGo: GitHub OAuth資格情報をBasic認証ヘッダーで送る

### DIFF
--- a/app/functions-go/sanpai.go
+++ b/app/functions-go/sanpai.go
@@ -136,8 +136,8 @@ func fetchGitHubFeed(ctx context.Context, username string) ([]feedItem, error) {
 	clientSecret := os.Getenv("GITHUB_CLIENT_SECRET")
 
 	reqURL := fmt.Sprintf(
-		"%s/users/%s/events/public?per_page=100&client_id=%s&client_secret=%s",
-		githubAPIBaseURL, url.PathEscape(username), url.QueryEscape(clientID), url.QueryEscape(clientSecret),
+		"%s/users/%s/events/public?per_page=100",
+		githubAPIBaseURL, url.PathEscape(username),
 	)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
@@ -145,6 +145,14 @@ func fetchGitHubFeed(ctx context.Context, username string) ([]feedItem, error) {
 	}
 	// GitHub API は User-Agent ヘッダーが無いリクエストを拒否するため必須。
 	req.Header.Set("User-Agent", "debug-shrine-sanpaiGo")
+	// OAuth Appの資格情報はBasic認証ヘッダーで送る。旧来のクエリパラメータ認証
+	// (?client_id=...&client_secret=...)は2021-05-05にGitHub APIから撤廃されており、
+	// 付けても単に無視されて未認証(IPごと60req/h)として扱われるため、
+	// 認証済みのレート制限(5000req/h)を得るにはヘッダーで送る必要がある。
+	// https://docs.github.com/en/rest/overview/authenticating-to-the-rest-api
+	if clientID != "" && clientSecret != "" {
+		req.SetBasicAuth(clientID, clientSecret)
+	}
 
 	resp, err := githubHTTPClient.Do(req)
 	if err != nil {

--- a/app/functions-go/sanpai_test.go
+++ b/app/functions-go/sanpai_test.go
@@ -81,6 +81,52 @@ func setupTestUser(t *testing.T, ctx context.Context, client *firestore.Client, 
 	}
 }
 
+// GitHub OAuth Appの資格情報がBasic認証ヘッダーで送られること
+// (廃止済みのクエリパラメータ認証を使っていないこと)を確認する。
+// Firestoreエミュレータ不要の純粋なHTTPテスト。
+func TestFetchGitHubFeed_SendsBasicAuthHeader(t *testing.T) {
+	t.Setenv("GITHUB_CLIENT_ID", "test-client-id")
+	t.Setenv("GITHUB_CLIENT_SECRET", "test-client-secret")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "test-client-id" || pass != "test-client-secret" {
+			t.Errorf("expected Basic auth with OAuth app credentials, got ok=%v user=%q", ok, user)
+		}
+		if r.URL.Query().Get("client_id") != "" || r.URL.Query().Get("client_secret") != "" {
+			t.Errorf("credentials must not be sent as query parameters (removed by GitHub API): %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+	withMockGitHub(t, srv)
+
+	if _, err := fetchGitHubFeed(context.Background(), "octocat"); err != nil {
+		t.Fatalf("fetchGitHubFeed: %v", err)
+	}
+}
+
+// 資格情報が未設定(空)のときは Authorization ヘッダーを付けないことを確認する。
+func TestFetchGitHubFeed_NoCredentials(t *testing.T) {
+	t.Setenv("GITHUB_CLIENT_ID", "")
+	t.Setenv("GITHUB_CLIENT_SECRET", "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("Authorization header must be empty when credentials are not configured, got %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+	withMockGitHub(t, srv)
+
+	if _, err := fetchGitHubFeed(context.Background(), "octocat"); err != nil {
+		t.Fatalf("fetchGitHubFeed: %v", err)
+	}
+}
+
 func TestSanpai_NotRegistered(t *testing.T) {
 	client := emulatorClient(t)
 	ctx := context.Background()


### PR DESCRIPTION
GitHub Events API 呼び出しで、OAuth Appの client_id/client_secret をクエリパラメータ(?client_id=&client_secret=)ではなくBasic認証ヘッダーで送るよう修正する。

クエリパラメータでの認証は2021-05-05にGitHub APIから撤廃されており、付けても無視されて未認証(IPあたり60req/h)として扱われる。認証済みのレート制限(5000req/h)を得るにはヘッダーで送る必要がある。参拝が集中するとレート制限に達し、以降の参拝が missing server error になり得る。

資格情報が未設定のときは Authorization ヘッダーを付けない。テストを2本追加。