### PR TITLE
auth middleware: 認証リスナーの多重登録を解消しログアウトの重複dispatchを防ぐ

### DIFF
--- a/web/middleware/auth.js
+++ b/web/middleware/auth.js
@@ -1,22 +1,26 @@
 import { getAuth, onAuthStateChanged } from 'firebase/auth';
 
-function firebaseAuthCheck(store) {
-  return new Promise(resolve => {
-    console.log('firebase_auth_check')
-    // 認証インスタンスの取得
-    const auth = getAuth();
-    onAuthStateChanged(auth, (user) => {
-      if (!user) {
-        store.dispatch('logout');
-      }
-    });
-    resolve();
-  })
+// Firebase Authのサインアウト検知はアプリ全体で1つの購読があれば足りる。
+// 以前はミドルウェア実行(=ルート遷移)のたびに onAuthStateChanged を登録して
+// 解除もしていなかったため、リスナーが遷移回数分だけ蓄積し、サインアウト時に
+// logout アクションが多重dispatchされていた(router.push('/') の重複実行を含む)。
+let authWatcherRegistered = false;
+
+function watchFirebaseAuth(store) {
+  if (authWatcherRegistered) return;
+  authWatcherRegistered = true;
+  const auth = getAuth();
+  onAuthStateChanged(auth, (user) => {
+    // 既にログアウト済みの状態で重ねて logout を dispatch しない
+    if (!user && store.state.user) {
+      store.dispatch('logout');
+    }
+  });
 }
 
-export default async function ({ redirect, store }) {
+export default function ({ redirect, store }) {
   if (!store.state.user) {
     return redirect('/');
   }
-  await firebaseAuthCheck(store);
+  watchFirebaseAuth(store);
 }


### PR DESCRIPTION
認証ミドルウェアは、認証が必要なページへ遷移するたびに onAuthStateChanged を登録し、解除関数を捨てていた。そのためリスナーが遷移回数分だけ蓄積し(リーク)、サインアウト時に logout アクションが多重にdispatchされていた(signOut と router.push('/') の重複実行を含む。後者は vue-router の NavigationDuplicated エラーになる)。

アプリ全体で1回だけ購読するよう修正し、あわせて既にログアウト済みのときは logout を再dispatchしないガードを入れた。