### PR TITLE
profile page: og:image を撤去済みの userOGP から userOGPGo に修正

### DIFF
--- a/web/pages/u/_userName.vue
+++ b/web/pages/u/_userName.vue
@@ -131,7 +131,7 @@ export default {
         {
           hid: "og:image",
           property: "og:image",
-          content: `${this.$config.apiUrl}userOGP?user=${this.$route.params.userName}`,
+          content: `${this.$config.apiUrl}userOGPGo?user=${this.$route.params.userName}`,
         },
         { hid: "og:title", name: "og:title", content: "でばっぐ神社" },
       ],


### PR DESCRIPTION
web/pages/u/_userName.vue の og:image が、Go全面移行で撤去された旧Node関数 userOGP を参照したままだった。稼働中の userOGPGo を指すよう修正する。

なお SNS クローラが参照する OGP は Firebase Hosting の /u/* リライト経由で ogpRewriteGo が書き換えた HTML 側のため、影響は SPA 内の meta タグに限られる。