### PR TITLE
sw-update: 初回訪問タブで新デプロイの自動リロードが効かない不具合を修正

### DIFF
--- a/web/plugins/sw-update.client.js
+++ b/web/plugins/sw-update.client.js
@@ -9,11 +9,19 @@ export default () => {
 
   // プラグイン起動時点で既に SW に制御されているか。
   // 初回インストール(制御なし→あり)ではリロード不要なため区別する。
-  const hadController = !!navigator.serviceWorker.controller;
+  // 初回インストール後は制御下に入るので true に更新する(固定のままだと、
+  // 初回訪問のタブでは以降の新デプロイでも一切リロードされなくなる)。
+  let hasController = !!navigator.serviceWorker.controller;
 
   let reloading = false;
   navigator.serviceWorker.addEventListener("controllerchange", () => {
-    if (reloading || !hadController) return;
+    if (!hasController) {
+      // 初回インストールによる制御開始。リロードは不要だが、次回以降の
+      // controllerchange は新デプロイによる切替なのでリロード対象にする。
+      hasController = true;
+      return;
+    }
+    if (reloading) return;
     reloading = true;
     window.location.reload();
   });


### PR DESCRIPTION
Service Worker 更新検知プラグインが、起動時の制御状態を hadController に固定していたため、初回訪問(制御なし→あり)のまま開きっぱなしのタブでは、以降どれだけ新デプロイがあっても controllerchange でのリロードが一切発火しなかった。

初回インストールによる制御開始を検知した時点でフラグを立て、それ以降の切替(=新デプロイ)ではリロードするよう修正する。