### PR TITLE
参拝ローディングの文言と鳥居の位置依存を解消

### DIFF
--- a/web/components/Loading.vue
+++ b/web/components/Loading.vue
@@ -34,7 +34,7 @@
 
         <!-- 巡回するメッセージ -->
         <transition name="msg" mode="out-in">
-          <div class="fs-2 mt-4 loading-message" :key="currentMessage">
+          <div class="mt-4 loading-message" :key="currentMessage">
             {{ currentMessage }}<span class="loading-dots"></span>
           </div>
         </transition>
@@ -215,7 +215,17 @@ export default {
 .loading-message {
   color: #fff;
   text-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
-  min-height: 2.2em;
+  /* 文字量に依存しない固定の表示領域にする。メッセージが何文字でも
+     高さが変わらないため、上に並ぶ鳥居(神社)の位置がずれない。 */
+  height: 2.4em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* 短い文言なので改行させない(中途半端な位置で折り返さない)。
+     画面幅が狭くても1行がはみ出さないよう font-size を可変にする。 */
+  white-space: nowrap;
+  font-size: clamp(1.1rem, 4.8vw, 2rem);
+  line-height: 1.2;
 }
 .loading-dots::after {
   content: "";


### PR DESCRIPTION
## 背景

参拝待ちのローディング画面（`Loading.vue`）は【鳥居 → 提灯 → メッセージ】を縦に並べ、`.inner` を `translateY(-50%)` で画面中央にセンタリングしている。巡回メッセージが長くて折り返すとブロック全体の高さが増え、センタリングの都合で**鳥居（神社）が上にずれて**かっこ悪かった（`.loading-message` が `min-height` のため2行で伸びる）。

## 変更内容（`web/components/Loading.vue`）

- `.loading-message` を**固定高（`height: 2.4em`）+ flex中央寄せ**にし、文字量に依存せず領域高さが一定になるようにした。これで上に並ぶ鳥居の位置がメッセージの行数で動かない（＝文字領域と神社描画の依存を解消）。
- **`white-space: nowrap`** で改行を止め、中途半端な位置での折り返しをなくした（文言は元々短いため折り返し不要）。
- 画面幅が狭くても1行がはみ出さないよう **`font-size: clamp(1.1rem, 4.8vw, 2rem)`** の可変にした（テンプレートの `fs-2` は撤去し、CSS側で制御）。

## 検証

実機幅（390px）で最長文言「御神木にお伺いを立てています」が1行に収まり、鳥居が短文時と同一位置に留まることをヘッドレスブラウザ（Chromium）で描画確認済み。旧実装では同文言が2行に折り返し鳥居が上にずれることも再現確認した。

対象は純粋にローディング画面のスタイルのみで、参拝ロジック・APIには影響しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_