### PR TITLE
おみくじ演出の全面改修:操作制限・鈴の緒スイング・連鎖完走・狐の作り込み

### DIFF
--- a/web/components/FoxSprite.vue
+++ b/web/components/FoxSprite.vue
@@ -1,0 +1,152 @@
+<template>
+  <!--
+    お稲荷さんの狐スプライト(SVG)。体・しっぽ・耳・足・顔を持ち、
+    pose プロパティでポーズを切り替える(sleep/idle/crouch/jump/land/happy)。
+    位置移動(left/bottom)や向き(flip)は親側で制御し、ここは姿勢のみ担当。
+  -->
+  <svg
+    class="fox-svg"
+    :class="'pose-' + pose"
+    viewBox="0 0 120 92"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <!-- しっぽ(ふさふさ・白い先) -->
+    <g class="tail">
+      <path
+        d="M36,60 C14,66 2,52 8,32 C11,44 18,50 26,53 C20,44 18,36 22,26 C28,38 36,48 44,54 Z"
+        fill="#f08c3e"
+      />
+      <path d="M8,32 C10,40 15,47 22,51 C18,42 18,34 22,26 C15,28 10,29 8,32 Z" fill="#fff4e4" />
+    </g>
+
+    <!-- 後ろ足 -->
+    <g class="legs legs-back">
+      <rect x="36" y="62" width="6" height="16" rx="3" fill="#5b3b23" />
+      <rect x="46" y="64" width="6" height="14" rx="3" fill="#5b3b23" />
+    </g>
+
+    <!-- 体 -->
+    <ellipse cx="54" cy="58" rx="26" ry="16" fill="#f08c3e" />
+    <circle cx="41" cy="59" r="14" fill="#e57f33" />
+    <ellipse cx="63" cy="64" rx="10" ry="8" fill="#fff4e4" />
+
+    <!-- 前足 -->
+    <g class="legs legs-front">
+      <rect x="64" y="62" width="6" height="17" rx="3" fill="#5b3b23" />
+      <rect x="72" y="63" width="6" height="16" rx="3" fill="#5b3b23" />
+    </g>
+
+    <!-- 頭 -->
+    <g class="head">
+      <!-- 耳 -->
+      <g class="ear ear-l">
+        <path d="M63,25 L59,5 L75,17 Z" fill="#f08c3e" />
+        <path d="M64,21 L62,10 L71,17 Z" fill="#7a4a26" />
+      </g>
+      <g class="ear ear-r">
+        <path d="M85,22 L95,3 L99,23 Z" fill="#f08c3e" />
+        <path d="M88,19 L93,9 L95,20 Z" fill="#7a4a26" />
+      </g>
+      <!-- 顔 -->
+      <circle cx="79" cy="34" r="17" fill="#f08c3e" />
+      <ellipse cx="89" cy="42" rx="11" ry="8" fill="#fff4e4" />
+      <circle cx="98" cy="40" r="2.8" fill="#402b1e" />
+      <!-- 目(開き) -->
+      <g class="eyes-open">
+        <circle cx="73" cy="31" r="2.5" fill="#402b1e" />
+        <circle cx="86" cy="31" r="2.5" fill="#402b1e" />
+      </g>
+      <!-- 目(閉じ=にっこり) -->
+      <g class="eyes-closed">
+        <path d="M70,31 Q73,28.5 76,31" stroke="#402b1e" stroke-width="1.8" fill="none" stroke-linecap="round" />
+        <path d="M83,31 Q86,28.5 89,31" stroke="#402b1e" stroke-width="1.8" fill="none" stroke-linecap="round" />
+      </g>
+      <!-- ほっぺ -->
+      <circle class="blush" cx="70" cy="39" r="3" fill="#ff9d68" opacity="0.55" />
+    </g>
+  </svg>
+</template>
+
+<script>
+export default {
+  props: {
+    // sleep | idle | crouch | jump | land | happy
+    pose: { type: String, default: "idle" },
+  },
+};
+</script>
+
+<style scoped>
+.fox-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+  transform-origin: 50% 100%;
+  transition: transform 0.16s ease;
+}
+.fox-svg .head,
+.fox-svg .tail,
+.fox-svg .legs,
+.fox-svg .ear {
+  transition: transform 0.16s ease;
+}
+.fox-svg .head { transform-origin: 76px 40px; }
+.fox-svg .tail { transform-origin: 38px 58px; }
+.fox-svg .ear-l { transform-origin: 66px 22px; }
+.fox-svg .ear-r { transform-origin: 92px 20px; }
+.fox-svg .legs { transform-origin: 55px 62px; }
+
+/* 目はポーズで開閉(既定は開き) */
+.fox-svg .eyes-closed { display: none; }
+
+/* --- 寝てる(丸まって目を閉じ、しっぽを抱える) --- */
+.pose-sleep {
+  transform: scaleY(0.82) translateY(4px);
+}
+.pose-sleep .head { transform: translate(-3px, 10px) rotate(16deg); }
+.pose-sleep .tail { transform: rotate(-18deg) translate(4px, -2px); }
+.pose-sleep .legs { transform: scaleY(0.45) translateY(6px); }
+.pose-sleep .ear-l,
+.pose-sleep .ear-r { transform: rotate(-12deg); }
+.pose-sleep .eyes-open { display: none; }
+.pose-sleep .eyes-closed { display: block; }
+
+/* --- しゃがみ(ジャンプの溜め。おしりフリフリ) --- */
+.pose-crouch {
+  transform: scaleY(0.76) scaleX(1.06) translateY(4px);
+  animation: fox-wiggle 0.36s ease-in-out infinite;
+}
+.pose-crouch .head { transform: translateY(3px) rotate(-4deg); }
+.pose-crouch .ear-l, .pose-crouch .ear-r { transform: rotate(-14deg); }
+.pose-crouch .tail { transform: rotate(10deg); }
+@keyframes fox-wiggle {
+  0%, 100% { rotate: -2deg; }
+  50% { rotate: 2deg; }
+}
+
+/* --- ジャンプ(伸びて足をたたみ、しっぽが流れる) --- */
+.pose-jump {
+  transform: scaleY(1.12) scaleX(0.94);
+}
+.pose-jump .legs { transform: scaleY(0.5) translateY(5px); }
+.pose-jump .tail { transform: rotate(22deg); }
+.pose-jump .ear-l, .pose-jump .ear-r { transform: rotate(-18deg); }
+.pose-jump .head { transform: rotate(-6deg); }
+
+/* --- 着地(ぐしゃっと潰れる) --- */
+.pose-land {
+  transform: scaleY(0.7) scaleX(1.18) translateY(5px);
+}
+.pose-land .ear-l, .pose-land .ear-r { transform: rotate(6deg); }
+.pose-land .tail { transform: rotate(-8deg); }
+
+/* --- ご機嫌(本命に着地。しっぽパタパタ) --- */
+.pose-happy .tail { animation: fox-wag 0.5s ease-in-out infinite; }
+.pose-happy .eyes-open { display: none; }
+.pose-happy .eyes-closed { display: block; }
+@keyframes fox-wag {
+  0%, 100% { transform: rotate(-10deg); }
+  50% { transform: rotate(16deg); }
+}
+</style>

--- a/web/components/OmikujiScene.vue
+++ b/web/components/OmikujiScene.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="omikuji-scene" @click="onOverlayClick">
+  <div class="omikuji-scene" @click="onTap">
     <div ref="inner" class="scene-inner" :style="innerStyle">
-      <!-- 物理(鈴の緒 + 連鎖)キャンバス -->
-      <div ref="canvasWrap" class="canvas-wrap"></div>
+      <!-- からくり装置(鈴の緒・絵馬・水車・斜面)の物理キャンバス -->
+      <div v-if="!reducedMotion" ref="canvasWrap" class="canvas-wrap"></div>
 
       <!-- ビン(レア度)ラベル。毎回シャッフルした割当 -->
       <div class="bin-row">
@@ -10,41 +10,48 @@
           v-for="(tier, i) in tierByBin"
           :key="i"
           class="bin-slot"
-          :class="{ target: phase === 'done' && i === targetBinIndex }"
+          :class="{ target: targetGlow && i === targetBinIndex }"
         >
           <span class="bin-label" :class="'bl-' + tierKey(tier)">{{ tier }}</span>
         </div>
       </div>
 
-      <!-- 狐(DOMスプライト。スクリプトでホップ) -->
-      <div
-        v-show="phase === 'fox' || phase === 'done'"
-        class="fox"
-        :style="foxStyle"
-      >🦊</div>
+      <!-- 狐(DOMスプライト)。寝床で寝ていて、玉に起こされてビンを飛び移る -->
+      <div v-if="!reducedMotion" class="fox-wrap" :style="foxStyle">
+        <FoxSprite :pose="foxPose" :style="{ transform: 'scaleX(' + foxFlip + ')' }" />
+        <div v-if="foxPose === 'sleep'" class="bubble zzz">Zzz…</div>
+        <div v-if="showBang" class="bubble bang">!</div>
+      </div>
 
-      <!-- ヒント -->
+      <!-- 鈴が鳴った時の波紋 -->
+      <div v-if="ringPulse" class="ring-pulse" :style="bellPulseStyle"></div>
+
+      <!-- 案内 -->
       <div v-if="phase === 'ritual'" class="hint">
-        <div class="hint-title">鈴の緒を左右に振って参拝しよう</div>
-        <button class="btn btn-outline-light btn-sm mt-2" @click.stop="ringByButton">
-          鈴を鳴らす
-        </button>
+        <div v-if="!reducedMotion">
+          <div class="hint-title">鈴の緒(金色の房)をつかんで、左右に振ろう</div>
+          <a class="hint-fallback" href="javascript:void(0)" @click.stop="onRing">
+            うまく鳴らせないときはここをタップ
+          </a>
+        </div>
+        <div v-else>
+          <button class="btn btn-lg btn-danger" @click.stop="onRing">鈴を鳴らす</button>
+        </div>
       </div>
-      <div v-else-if="phase === 'cascade'" class="hint">
-        <div class="hint-title">御神籤が転がり出した…</div>
+      <div v-else-if="phase === 'cascade' || phase === 'fox'" class="hint skip">
+        タップでスキップ
       </div>
-      <div v-else-if="phase === 'fox'" class="hint skip">タップでスキップ</div>
     </div>
   </div>
 </template>
 
 <script>
 import Matter from "matter-js";
+import machine from "@/components/omikujiMachine";
 import { foxHopSequence } from "@/components/omikujiFox";
+import FoxSprite from "@/components/FoxSprite";
 
-// 論理座標(物理キャンバス)。DOMオーバーレイは % で合わせる。
-const W = 480;
-const H = 760;
+const GEO = machine.GEO;
 
 const TIER_KEYS = {
   超吉: "chokichi",
@@ -56,11 +63,21 @@ const TIER_KEYS = {
   大凶: "daikyo",
 };
 const ALL_TIERS = Object.keys(TIER_KEYS);
-const BIN_COUNT = 7;
+
+// 狐の座標(シーン内%)。物理の論理座標から換算した定数。
+const FOX = {
+  // 寝床(FOX_PLATFORM 上。右向きに寝て、おしりが左=玉の飛来方向)
+  sleepLeft: (372 / GEO.W) * 100,
+  sleepBottom: ((GEO.H - 620) / GEO.H) * 100,
+  // ビンの中に立つときの足元
+  binBottom: ((GEO.H - 744) / GEO.H) * 100,
+  widthPct: 17,
+};
 
 export default {
+  components: { FoxSprite },
   props: {
-    // 親が omikujiGo 応答後に渡す。null の間は儀式待ち。
+    // 親が omikujiGo 応答後に渡す。届くまでは装置と狐が場を繋ぐ。
     targetTier: { type: String, default: null },
   },
   data() {
@@ -68,27 +85,15 @@ export default {
       phase: "ritual", // ritual | cascade | fox | done
       tierByBin: ALL_TIERS.slice(),
       rung: false,
+      targetGlow: false,
       innerStyle: {},
-      // fox 表示状態(%)
-      foxLeft: 50,
-      foxBottom: 12,
-      foxScaleX: 1,
-      foxScaleY: 1,
-      foxFlip: 1,
-      // matter
-      engine: null,
-      render: null,
-      raf: null,
-      mouseConstraint: null,
-      ropeTip: null,
-      rope: null,
-      swingCount: 0,
-      lastSwingSign: 0,
-      // タイマ
-      cascadeTimer: null,
-      failsafe: null,
-      foxRaf: null,
-      destroyed: false,
+      // 狐
+      foxPose: "sleep",
+      foxLeft: FOX.sleepLeft,
+      foxBottom: FOX.sleepBottom,
+      foxFlip: 1, // 右向きで寝る(おしりを左=玉の飛来方向に向ける)
+      showBang: false,
+      ringPulse: false,
       reducedMotion: false,
     };
   },
@@ -100,15 +105,22 @@ export default {
       return {
         left: this.foxLeft + "%",
         bottom: this.foxBottom + "%",
-        transform: `translate(-50%, 0) scaleX(${this.foxScaleX * this.foxFlip}) scaleY(${this.foxScaleY})`,
+        width: FOX.widthPct + "%",
+      };
+    },
+    bellPulseStyle() {
+      return {
+        left: (GEO.BELL.x / GEO.W) * 100 + "%",
+        top: (GEO.BELL.y / GEO.H) * 100 + "%",
       };
     },
   },
   watch: {
+    // 鳴らし済みで tier が届き、装置パートが終わっていれば狐が動き出す
     targetTier(v) {
-      // 鳴らし済みで tier が届いたら、連鎖の後に狐へ進む(cascade 完了時に startFox が拾う)
-      if (v && this.rung && this.phase === "cascade" && this._cascadeDone) {
-        this.startFox();
+      if (v && this._waitingTarget) {
+        this._waitingTarget = false;
+        this.startHops();
       }
     },
   },
@@ -121,24 +133,33 @@ export default {
     this.shuffleBins();
     this.computeSize();
     window.addEventListener("resize", this.computeSize);
+    this._timers = [];
+    this._raf = null;
+    this._foxRaf = null;
+    this.destroyed = false;
 
-    if (this.reducedMotion) {
-      this.phase = "ritual"; // ボタンだけ
-      return;
+    if (!this.reducedMotion) {
+      this.$nextTick(() => this.initScene());
     }
-    this.$nextTick(() => this.initScene());
   },
   beforeDestroy() {
     this.destroyed = true;
     window.removeEventListener("resize", this.computeSize);
-    if (this.cascadeTimer) clearTimeout(this.cascadeTimer);
-    if (this.failsafe) clearTimeout(this.failsafe);
-    if (this.foxRaf) cancelAnimationFrame(this.foxRaf);
+    (this._timers || []).forEach(clearTimeout);
+    if (this._raf) cancelAnimationFrame(this._raf);
+    if (this._foxRaf) cancelAnimationFrame(this._foxRaf);
     this.teardownMatter();
   },
   methods: {
     tierKey(t) {
       return TIER_KEYS[t] || "";
+    },
+    later(ms, fn) {
+      const id = setTimeout(() => {
+        if (!this.destroyed) fn();
+      }, ms);
+      this._timers.push(id);
+      return id;
     },
     shuffleBins() {
       const a = ALL_TIERS.slice();
@@ -153,230 +174,216 @@ export default {
     computeSize() {
       const vw = window.innerWidth;
       const vh = window.innerHeight;
-      const ratio = W / H;
-      let w = Math.min(vw * 0.94, vh * 0.84 * ratio, 460);
+      const ratio = GEO.W / GEO.H;
+      let w = Math.min(vw * 0.96, vh * 0.9 * ratio, 460);
       const h = w / ratio;
       this.innerStyle = { width: Math.round(w) + "px", height: Math.round(h) + "px" };
     },
     binLeftPct(i) {
-      return ((i + 0.5) / BIN_COUNT) * 100;
+      return ((i + 0.5) / GEO.BIN_COUNT) * 100;
     },
 
-    // ---- 物理シーン(鈴の緒 + 連鎖の土台) ----
+    // ---- 物理シーン(からくり装置+鈴の緒) ----
     initScene() {
       if (this.destroyed || !this.$refs.canvasWrap) return;
-      const engine = Matter.Engine.create();
-      engine.gravity.scale = 0.001;
+      const { engine, world, tassel } = machine.buildMachineWorld(Matter);
       this.engine = engine;
-      const world = engine.world;
-      const add = (b) => Matter.World.add(world, b);
-
-      // 外壁・床
-      add([
-        Matter.Bodies.rectangle(-6, H / 2, 12, H, { isStatic: true, render: { fillStyle: "#3a3230" } }),
-        Matter.Bodies.rectangle(W + 6, H / 2, 12, H, { isStatic: true, render: { fillStyle: "#3a3230" } }),
-        Matter.Bodies.rectangle(W / 2, H - 30, W, 16, { isStatic: true, render: { fillStyle: "#3a3230" } }),
-      ]);
-
-      // 連鎖の土台(見せ場・結果には無関係):斜面 + ドミノ + 自由回転の風車
-      add(Matter.Bodies.rectangle(150, 330, 260, 12, { isStatic: true, angle: 0.28, render: { fillStyle: "#7a5230" } }));
-      add(Matter.Bodies.rectangle(340, 440, 260, 12, { isStatic: true, angle: -0.28, render: { fillStyle: "#7a5230" } }));
-      this.dominoes = [];
-      for (let i = 0; i < 5; i++) {
-        const d = Matter.Bodies.rectangle(300 + i * 24, 512, 8, 40, { density: 0.002, render: { fillStyle: "#cdbba8" } });
-        this.dominoes.push(d);
-        add(d);
-      }
-      const spin = Matter.Body.create({
-        parts: [Matter.Bodies.rectangle(0, 0, 110, 12), Matter.Bodies.rectangle(0, 0, 12, 110)],
-        density: 0.0012,
-        render: { fillStyle: "#e0663c" },
-      });
-      Matter.Body.setPosition(spin, { x: 150, y: 470 });
-      add(spin);
-      add(Matter.Constraint.create({ pointA: { x: 150, y: 470 }, bodyB: spin, pointB: { x: 0, y: 0 }, length: 0, stiffness: 1, render: { visible: false } }));
-
-      // 鈴の緒(制約チェーン)
-      const anchorX = W / 2;
-      const anchorY = 22;
-      const N = 6;
-      const segH = 15;
-      const group = Matter.Body.nextGroup(true);
-      const rope = Matter.Composites.stack(anchorX - 3.5, anchorY + 6, 1, N, 0, 0, (x, y) =>
-        Matter.Bodies.rectangle(x, y, 7, segH, { collisionFilter: { group }, render: { fillStyle: "#b23a48" } })
-      );
-      Matter.Composites.chain(rope, 0, 0.5, 0, -0.5, { stiffness: 0.9, length: 0, render: { strokeStyle: "#b23a48", lineWidth: 3 } });
-      Matter.Composite.add(rope, Matter.Constraint.create({ pointA: { x: anchorX, y: anchorY }, bodyB: rope.bodies[0], pointB: { x: 0, y: -segH / 2 }, stiffness: 0.95, length: 0, render: { strokeStyle: "#b23a48", lineWidth: 3 } }));
-      this.ropeTip = rope.bodies[rope.bodies.length - 1];
-      this.ropeTip.render.fillStyle = "#e8c86a";
-      Matter.World.add(world, rope);
-      this.rope = rope;
-
-      // 鈴(飾り)
-      add(Matter.Bodies.circle(anchorX, anchorY - 4, 12, { isStatic: true, render: { fillStyle: "#e8c86a" } }));
+      this.tassel = tassel;
 
       this.render = Matter.Render.create({
         element: this.$refs.canvasWrap,
         engine,
-        options: { width: W, height: H, wireframes: false, background: "transparent", pixelRatio: window.devicePixelRatio || 1 },
+        options: {
+          width: GEO.W,
+          height: GEO.H,
+          wireframes: false,
+          background: "transparent",
+          pixelRatio: window.devicePixelRatio || 1,
+        },
       });
       this.render.canvas.style.width = "100%";
       this.render.canvas.style.height = "100%";
       Matter.Render.run(this.render);
 
+      // 鈴の緒「だけ」掴める(カテゴリで制限。装置や玉は操作不可)
       const mouse = Matter.Mouse.create(this.render.canvas);
-      this.mouseConstraint = Matter.MouseConstraint.create(engine, { mouse, constraint: { stiffness: 0.2, render: { visible: false } } });
+      this.mouseConstraint = Matter.MouseConstraint.create(engine, {
+        mouse,
+        collisionFilter: { category: GEO.CAT_MOUSE, mask: GEO.CAT_ROPE },
+        constraint: { stiffness: 0.18, render: { visible: false } },
+      });
       Matter.World.add(world, this.mouseConstraint);
       this.render.mouse = mouse;
 
+      // 玉(または飛んだ絵馬)が狐のおしりに直撃 → 目を覚ます
+      Matter.Events.on(engine, "collisionStart", (e) => {
+        if (this.phase !== "cascade") return;
+        for (const p of e.pairs) {
+          const labels = [p.bodyA.label, p.bodyB.label];
+          if (labels.includes("fox-sensor") && (labels.includes("ball") || labels.includes("ema"))) {
+            this.wakeFox();
+            return;
+          }
+        }
+      });
+
+      // 手動固定ステップ(揺れ検知は儀式中のみ)
       const step = () => {
         if (this.destroyed) return;
-        Matter.Engine.update(engine, 1000 / 60, 1);
+        Matter.Engine.update(this.engine, GEO.FIXED_DELTA, 1);
         if (this.phase === "ritual") this.trackSwing();
-        this.raf = requestAnimationFrame(step);
+        this._raf = requestAnimationFrame(step);
       };
-      this.raf = requestAnimationFrame(step);
+      this._raf = requestAnimationFrame(step);
     },
+
+    // 鈴の緒のスイング検知:房の x が中心から左右のしきい値を交互に越えたら
+    // 「振った」と数える(往復1.5回で鳴る。振幅ベースなので判定が安定)
     trackSwing() {
-      if (!this.ropeTip || this.rung) return;
-      const vx = this.ropeTip.velocity.x;
-      const sign = vx > 3 ? 1 : vx < -3 ? -1 : 0;
-      if (sign !== 0 && this.lastSwingSign !== 0 && sign !== this.lastSwingSign) this.swingCount++;
-      if (sign !== 0) this.lastSwingSign = sign;
-      if (this.swingCount >= 4) this.onRing();
+      if (!this.tassel || this.rung) return;
+      const dx = this.tassel.position.x - GEO.BELL.x;
+      const TH = 26;
+      const side = dx > TH ? 1 : dx < -TH ? -1 : 0;
+      if (side !== 0 && side !== this._lastSide) {
+        if (this._lastSide === 1 || this._lastSide === -1) this._swings = (this._swings || 0) + 1;
+        this._lastSide = side;
+      }
+      if ((this._swings || 0) >= 3) this.onRing();
     },
-    ringByButton() {
-      this.onRing();
-    },
+
     onRing() {
       if (this.rung) return;
       this.rung = true;
       this.$emit("rang");
+      this.ringPulse = true;
+      this.later(900, () => (this.ringPulse = false));
 
       if (this.reducedMotion) {
-        // 演出なし:tier が来次第 landed
+        // 演出なし:tier が届き次第すぐ結果へ
+        this.phase = "cascade";
         this.waitTargetThen(() => this.finish());
         return;
       }
 
       this.phase = "cascade";
-      // 鈴の緒を外し、玉を落として連鎖を見せる
-      if (this.rope) Matter.World.remove(this.engine.world, this.rope);
-      if (this.mouseConstraint) Matter.World.remove(this.engine.world, this.mouseConstraint);
-      const ball = Matter.Bodies.circle(W / 2, 70, 12, { restitution: 0.5, frictionAir: 0.004, density: 0.004, render: { fillStyle: "#ff5a3c" } });
-      Matter.Body.setVelocity(ball, { x: 1.5, y: 0 });
-      Matter.World.add(this.engine.world, ball);
-      this.ball = ball;
-
-      // 連鎖はタイムボックスで必ず前進(約4.2秒)→ 狐へ
-      this._cascadeDone = false;
-      this.cascadeTimer = setTimeout(() => {
-        this._cascadeDone = true;
-        if (this.targetTier) this.startFox();
-        // targetTier 未着なら watch で拾う
-      }, 4200);
-
+      // 掴み操作はもう終わり(装置には最初から触れない)
+      if (this.mouseConstraint && this.engine) {
+        Matter.World.remove(this.engine.world, this.mouseConstraint);
+        this.mouseConstraint = null;
+      }
+      // 鈴から御神玉を放つ
+      this.later(300, () => {
+        if (this.engine) machine.spawnBall(Matter, this.engine.world, 0.2);
+      });
+      // タイムボックス:装置が万一詰まっても狐は起きる(通常は約12秒で直撃)
+      this.later(15000, () => this.wakeFox());
       // 全体フェイルセーフ
-      this.failsafe = setTimeout(() => {
-        if (!this.destroyed && this.phase !== "done") this.finish();
-      }, 24000);
+      this.later(30000, () => this.finish());
     },
     waitTargetThen(cb) {
       if (this.targetTier) return cb();
-      this._tWatch = setInterval(() => {
-        if (this.destroyed) return clearInterval(this._tWatch);
+      const id = setInterval(() => {
+        if (this.destroyed) return clearInterval(id);
         if (this.targetTier) {
-          clearInterval(this._tWatch);
+          clearInterval(id);
           cb();
         }
       }, 100);
+      this._timers.push(id);
     },
 
-    // ---- 狐セレクタ(結果を決める。スクリプトで必ずターゲットへ) ----
-    startFox() {
-      if (this.phase === "fox" || this.phase === "done") return;
+    // ---- 狐(結果を決める1個。最後は必ずサーバーの tier のビンへ) ----
+    wakeFox() {
+      if (this.phase !== "cascade") return;
       this.phase = "fox";
-      // 物理は畳んで軽くする(見た目は残ってOKだが負荷減)
-      this.teardownMatter();
-
-      const target = this.tierByBin.indexOf(this.targetTier);
-      const seq = foxHopSequence(target < 0 ? 0 : target, BIN_COUNT);
-      // スタートは左端外から
-      this.foxLeft = this.binLeftPct(seq[0]);
-      this.foxBottom = 12;
-      this.hopQueue = seq.slice();
-      this.currentBin = seq[0];
-      // 最初のビンへ"登場"してから順に飛び移る
-      this.runHops(1);
-    },
-    runHops(idx) {
-      if (this.destroyed) return;
-      if (idx >= this.hopQueue.length) {
-        // 本命に着地済み。少し溜めてから結果へ。
-        this.foxSettle();
-        setTimeout(() => {
-          if (!this.destroyed) this.finish();
-        }, 800);
-        return;
-      }
-      const fromBin = this.hopQueue[idx - 1];
-      const toBin = this.hopQueue[idx];
-      const isFinal = idx === this.hopQueue.length - 1;
-      this.animateHop(fromBin, toBin, isFinal, () => {
-        // 着地後の"溜め"(ハラハラ)。本命前は少し長め。
-        const pause = isFinal ? 260 : 220;
-        setTimeout(() => this.runHops(idx + 1), pause);
+      // 「!」と共に目を覚ます(物理はそのまま残す=玉や装置の余韻が見える)
+      this.showBang = true;
+      this.foxPose = "idle";
+      this.later(750, () => {
+        this.showBang = false;
+        if (this.targetTier) this.startHops();
+        else {
+          this._waitingTarget = true; // 応答待ち(通常は先に届いている)
+          this.waitTargetThen(() => {
+            if (this._waitingTarget) {
+              this._waitingTarget = false;
+              this.startHops();
+            }
+          });
+        }
       });
     },
-    animateHop(fromBin, toBin, isFinal, done) {
-      const x0 = this.binLeftPct(fromBin);
-      const x1 = this.binLeftPct(toBin);
-      this.foxFlip = x1 >= x0 ? 1 : -1;
-      const dur = isFinal ? 620 : 460;
-      const apex = 26 + Math.min(30, Math.abs(x1 - x0)); // 距離で弧の高さ
-      const t0 = performance.now();
-      const tick = () => {
-        if (this.destroyed) return;
-        const t = Math.min(1, (performance.now() - t0) / dur);
-        const e = t; // 線形でOK(弧で見栄えを作る)
-        this.foxLeft = x0 + (x1 - x0) * e;
-        this.foxBottom = 12 + apex * Math.sin(Math.PI * t);
-        // スクワッシュ&ストレッチ:離陸/着地で潰れ、空中で伸びる
-        const air = Math.sin(Math.PI * t);
-        this.foxScaleY = 1 + 0.22 * air;
-        this.foxScaleX = 1 - 0.16 * air;
-        if (t < 1) {
-          this.foxRaf = requestAnimationFrame(tick);
-        } else {
-          this.foxBottom = 12;
-          this.foxScaleX = 1.18;
-          this.foxScaleY = 0.82; // 着地の潰れ
-          setTimeout(() => {
-            this.foxScaleX = 1;
-            this.foxScaleY = 1;
-          }, 90);
-          done();
-        }
-      };
-      this.foxRaf = requestAnimationFrame(tick);
+    startHops() {
+      if (this.destroyed || this.phase === "done") return;
+      const target = this.targetBinIndex >= 0 ? this.targetBinIndex : 0;
+      this.hopSeq = foxHopSequence(target, GEO.BIN_COUNT);
+      this.hopIndex = 0;
+      // まず寝床からひと跳びで最初のビンへ
+      this.doHop(this.foxLeft, this.binLeftPct(this.hopSeq[0]), FOX.binBottom, false, () => {
+        this.later(500, () => this.nextHop());
+      });
     },
-    foxSettle() {
-      this.foxScaleX = 1;
-      this.foxScaleY = 1;
-      this.foxBottom = 12;
+    nextHop() {
+      if (this.destroyed || this.phase === "done") return;
+      this.hopIndex++;
+      if (this.hopIndex >= this.hopSeq.length) {
+        // 本命に着地済み → ご機嫌ポーズ+ビンが光って、溜めてから結果へ
+        this.foxPose = "happy";
+        this.targetGlow = true;
+        this.later(1000, () => this.finish());
+        return;
+      }
+      const from = this.binLeftPct(this.hopSeq[this.hopIndex - 1]);
+      const to = this.binLeftPct(this.hopSeq[this.hopIndex]);
+      const isFinal = this.hopIndex === this.hopSeq.length - 1;
+      this.doHop(from, to, FOX.binBottom, isFinal, () => {
+        // 着地後の間(キョロキョロ)。本命前は長めに焦らす
+        this.later(isFinal ? 250 : 550 + Math.random() * 350, () => this.nextHop());
+      });
+    },
+    // 1回のジャンプ:溜め(しゃがみ・おしりフリフリ)→ 放物線 → 着地の潰れ
+    doHop(fromLeft, toLeft, toBottom, isFinal, done) {
+      this.foxFlip = toLeft >= fromLeft ? 1 : -1;
+      this.foxPose = "crouch";
+      const crouchMs = isFinal ? 780 : 430;
+      this.later(crouchMs, () => {
+        this.foxPose = "jump";
+        const fromBottom = this.foxBottom;
+        const dur = isFinal ? 950 : 760;
+        const apex = 15 + Math.min(18, Math.abs(toLeft - fromLeft) * 0.3);
+        const t0 = performance.now();
+        const tick = () => {
+          if (this.destroyed) return;
+          const t = Math.min(1, (performance.now() - t0) / dur);
+          this.foxLeft = fromLeft + (toLeft - fromLeft) * t;
+          this.foxBottom = fromBottom + (toBottom - fromBottom) * t + apex * Math.sin(Math.PI * t);
+          if (t < 1) {
+            this._foxRaf = requestAnimationFrame(tick);
+          } else {
+            this.foxBottom = toBottom;
+            this.foxPose = "land";
+            this.later(170, () => {
+              if (this.foxPose === "land") this.foxPose = "idle";
+            });
+            done();
+          }
+        };
+        this._foxRaf = requestAnimationFrame(tick);
+      });
     },
 
     finish() {
       if (this.phase === "done") return;
       this.phase = "done";
+      this.targetGlow = true;
       this.$emit("landed", { tier: this.targetTier });
     },
-    onOverlayClick() {
+    onTap() {
+      // 演出中はタップでスキップ(儀式中は誤爆防止のため無効。fallbackリンクを使う)
       if (this.phase === "cascade" || this.phase === "fox") this.finish();
     },
+
     teardownMatter() {
-      if (this.raf) cancelAnimationFrame(this.raf);
-      this.raf = null;
       if (this.render) {
         Matter.Render.stop(this.render);
         if (this.render.canvas && this.render.canvas.remove) this.render.canvas.remove();
@@ -389,9 +396,7 @@ export default {
         this.engine = null;
       }
       this.mouseConstraint = null;
-      this.ropeTip = null;
-      this.rope = null;
-      this.ball = null;
+      this.tassel = null;
     },
   },
 };
@@ -408,6 +413,7 @@ export default {
   align-items: center;
   justify-content: center;
   user-select: none;
+  touch-action: none; /* スワイプで鈴の緒を振れるように(画面スクロールを止める) */
 }
 .scene-inner {
   position: relative;
@@ -415,6 +421,7 @@ export default {
 .canvas-wrap {
   position: absolute;
   inset: 0;
+  touch-action: none;
 }
 .canvas-wrap canvas {
   display: block;
@@ -426,27 +433,25 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  height: 22%;
+  height: 13%;
   display: flex;
   pointer-events: none;
 }
 .bin-slot {
   flex: 1 1 0;
-  border-left: 2px solid rgba(255, 255, 255, 0.12);
   display: flex;
   align-items: flex-end;
   justify-content: center;
-  padding-bottom: 4px;
-  transition: background 0.3s;
+  padding-bottom: 3px;
+  transition: background 0.4s;
 }
-.bin-slot:first-child { border-left: none; }
 .bin-slot.target {
-  background: linear-gradient(to top, rgba(255, 210, 90, 0.35), transparent);
+  background: linear-gradient(to top, rgba(255, 210, 90, 0.4), transparent);
 }
 .bin-label {
   writing-mode: vertical-rl;
   font-weight: 800;
-  font-size: clamp(10px, 2.6vw, 16px);
+  font-size: clamp(10px, 2.6vw, 15px);
   color: #fff;
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
 }
@@ -459,34 +464,89 @@ export default {
 .bl-daikyo { color: #ff9a9a; }
 
 /* 狐 */
-.fox {
+.fox-wrap {
   position: absolute;
-  font-size: clamp(28px, 8vw, 44px);
-  line-height: 1;
-  transform-origin: 50% 100%;
-  will-change: left, bottom, transform;
-  filter: drop-shadow(0 3px 4px rgba(0, 0, 0, 0.5));
+  transform: translateX(-50%);
   pointer-events: none;
+  z-index: 3;
+}
+.bubble {
+  position: absolute;
+  color: #fff;
+  font-weight: 800;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+}
+.bubble.zzz {
+  top: -18px;
+  right: -6px;
+  font-size: 14px;
+  opacity: 0.9;
+  animation: zzz-float 2s ease-in-out infinite;
+}
+@keyframes zzz-float {
+  0%, 100% { transform: translateY(0); opacity: 0.55; }
+  50% { transform: translateY(-6px); opacity: 1; }
+}
+.bubble.bang {
+  top: -26px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 30px;
+  color: #ffd24d;
+  animation: bang-pop 0.35s ease-out;
+}
+@keyframes bang-pop {
+  0% { transform: translateX(-50%) scale(0.2); }
+  70% { transform: translateX(-50%) scale(1.3); }
+  100% { transform: translateX(-50%) scale(1); }
 }
 
+/* 鈴の波紋 */
+.ring-pulse {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 210, 90, 0.9);
+  transform: translate(-50%, -50%);
+  animation: ring-expand 0.9s ease-out forwards;
+  pointer-events: none;
+}
+@keyframes ring-expand {
+  0% { width: 20px; height: 20px; opacity: 1; }
+  100% { width: 130px; height: 130px; opacity: 0; }
+}
+
+/* 案内 */
 .hint {
   position: absolute;
-  top: 5%;
+  top: 4%;
   left: 0;
   right: 0;
   text-align: center;
   color: #fff;
   pointer-events: none;
+  z-index: 4;
 }
-.hint .btn { pointer-events: auto; }
+.hint .btn,
+.hint .hint-fallback {
+  pointer-events: auto;
+}
 .hint-title {
-  font-size: clamp(0.95rem, 3.6vw, 1.25rem);
+  font-size: clamp(0.9rem, 3.4vw, 1.15rem);
   text-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
+}
+.hint-fallback {
+  display: inline-block;
+  margin-top: 6px;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.75);
+  text-decoration: underline;
 }
 .hint.skip {
   top: auto;
-  bottom: 24%;
-  opacity: 0.7;
+  bottom: 15%;
+  opacity: 0.65;
   font-size: 0.85rem;
 }
 </style>

--- a/web/components/omikujiFox.js
+++ b/web/components/omikujiFox.js
@@ -15,8 +15,9 @@ function foxHopSequence(targetBin, binCount, rnd) {
   rnd = rnd || Math.random;
   if (binCount <= 1) return [targetBin];
 
-  // おとりの回数(2〜4)。ビンが少なければ抑える。
-  const maxDecoys = Math.min(4, binCount - 1);
+  // おとりの回数(2〜3)。1ホップに溜め・着地・間を含めて約2秒かけるため、
+  // 多すぎると尺が延びる。ビンが少なければさらに抑える。
+  const maxDecoys = Math.min(3, binCount - 1);
   const minDecoys = Math.min(2, maxDecoys);
   const decoys = minDecoys + Math.floor(rnd() * (maxDecoys - minDecoys + 1));
 

--- a/web/components/omikujiMachine.js
+++ b/web/components/omikujiMachine.js
@@ -1,0 +1,218 @@
+// おみくじ演出のからくり装置(matter-js)の構築モジュール。
+//
+// 描画(Render)を含まない構築部分だけを切り出し、Node でもヘッドレスに
+// 「玉が全ギミックを通って狐(センサー)に届くか」を検証できるようにする。
+//
+// 演出の流れ(すべてこの装置の上で起きる):
+//   鈴の緒を振る → 鈴が鳴り御神玉が落ちる
+//   → 斜面Aを右へ転がり、吊るされた絵馬をカランカランと揺らしながら駆け抜ける
+//   → 玉も水車に落ち、玉の重みで水車が回る(触れると動く仕掛け)
+//   → 斜面Bを左へ転がり、バンパーでポーンと上へ跳ねて折り返す
+//   → 斜面Cを右へ転がり、右下で寝ている狐のおしりに直撃
+//   → 狐が目を覚まし、ビンの上を飛び移る(狐は DOM スプライト側)
+//
+// 設計の要:
+// - 最終段は「玉が狐に直撃」。全初期条件で玉の飛行経路が同じ帯を通ることを
+//   Node で検証済みで、当たり判定をその帯に置くので連鎖の完走が安定する。
+// - 中段の仕掛けは「吊り絵馬(振り子)」。玉に押されて揺れるだけで道を塞がず、
+//   立ちドミノのように倒れて玉を止めることがない。
+// - 抽選の正しさはこの装置に依存しない(狐の最終着地は omikujiFox.js で制御)。
+//   装置が万一詰まってもタイムボックスで先に進む。
+
+const GEO = {
+  W: 480,
+  H: 760,
+  BIN_COUNT: 7,
+  FIXED_DELTA: 1000 / 60,
+
+  // collision categories(鈴の緒だけをマウスで掴めるようにする)
+  CAT_DEFAULT: 0x0001,
+  CAT_ROPE: 0x0002,
+  CAT_MOUSE: 0x0004,
+
+  BELL: { x: 240, y: 36, r: 17 },
+  ROPE: { segs: 7, segW: 7, segH: 16, tasselR: 13 },
+
+  BALL: { spawnX: 243, spawnY: 72, r: 11, density: 0.005, restitution: 0.2, friction: 0.01, frictionAir: 0.002 },
+
+  // 斜面A(1本の長い坂)。玉はここで加速しながら吊り絵馬をなぎ払う。
+  RAMP_A: { x: 270, y: 265, w: 380, h: 12, angle: 0.24 },
+  // 吊り絵馬(振り子)。玉が通るとカランカランと揺れる。立ちドミノと違い
+  // 倒れて道を塞ぐことがないため、連鎖が詰まらない。
+  EMA: { xs: [330, 385, 440], w: 10, h: 36, hang: 58, density: 0.001 },
+
+  // 水車(自由回転)。レッジの端から落ちる玉・ドミノで回る。
+  // 腕が右壁からはみ出さない大きさにし、玉の落下点の左に置いてトルクを得る。
+  WHEEL: { x: 420, y: 392, arm: 100, thick: 14, density: 0.0018, frictionAir: 0.02 },
+
+  // 斜面B(左下がり)。水車から落ちた玉を受けて左へ運ぶ。
+  RAMP_B: { x: 345, y: 482, w: 270, h: 12, angle: -0.13 },
+
+  // バンパー(よく弾む)。斜面Bを下ってきた玉をポーンと上へ跳ね上げ、
+  // 「下るだけ」の単調さを打破しつつ、折り返しの谷で玉が失速するのを防ぐ。
+  BUMPER: { x: 195, y: 532, r: 13, restitution: 1.05 },
+  // 斜面C(右下がり)。バンパーで跳ねた玉を受けて右へ折り返す。
+  RAMP_C: { x: 170, y: 575, w: 280, h: 12, angle: 0.2 },
+
+  // 狐の寝床(右下の台)。斜面Cから飛び出した玉が、寝ている狐のおしりに直撃。
+  FOX_PLATFORM: { x: 365, y: 625, w: 110, h: 10 },
+  FOX_LIP: { x: 415, y: 606, w: 8, h: 24 }, // 玉が右へ抜けないための縁
+  FOX_SENSOR: { x: 340, y: 603, w: 60, h: 38 },
+
+  BIN_TOP: 648,
+  FLOOR_Y: 744,
+};
+
+// 装置一式を組む。Matter を引数に取るのは Node(require)とブラウザ(webpack
+// import)の両対応のため。
+function buildMachineWorld(Matter) {
+  const { Engine, World, Bodies, Body, Composites, Composite, Constraint } = Matter;
+  const engine = Engine.create();
+  engine.gravity.scale = 0.001;
+  const world = engine.world;
+  const add = (b) => World.add(world, b);
+
+  const wood = { fillStyle: "#8a5a34" };
+
+  // 外壁・床
+  add([
+    Bodies.rectangle(-8, GEO.H / 2, 16, GEO.H, { isStatic: true, render: { fillStyle: "#3a3230" } }),
+    Bodies.rectangle(GEO.W + 8, GEO.H / 2, 16, GEO.H, { isStatic: true, render: { fillStyle: "#3a3230" } }),
+    Bodies.rectangle(GEO.W / 2, GEO.FLOOR_Y + 8, GEO.W, 16, { isStatic: true, render: { fillStyle: "#3a3230" } }),
+  ]);
+
+  // 鈴(飾り。玉はここから落ちる)
+  add(Bodies.circle(GEO.BELL.x, GEO.BELL.y, GEO.BELL.r, { isStatic: true, label: "bell", render: { fillStyle: "#e8c86a" } }));
+  add(Bodies.rectangle(GEO.BELL.x, GEO.BELL.y + 10, 10, 6, { isStatic: true, render: { fillStyle: "#8a6a2a" } }));
+
+  // 鈴の緒(制約チェーン)。マウスでだけ掴める(装置や玉とは衝突しない)。
+  const ropeFilter = { category: GEO.CAT_ROPE, mask: GEO.CAT_MOUSE };
+  const ropeTopY = GEO.BELL.y + GEO.BELL.r + 4;
+  const rope = Composites.stack(GEO.BELL.x - GEO.ROPE.segW / 2, ropeTopY, 1, GEO.ROPE.segs, 0, 0, (x, y) =>
+    Bodies.rectangle(x, y, GEO.ROPE.segW, GEO.ROPE.segH, {
+      collisionFilter: ropeFilter,
+      render: { fillStyle: "#b23a48" },
+    })
+  );
+  Composites.chain(rope, 0, 0.5, 0, -0.5, { stiffness: 0.9, length: 0, render: { strokeStyle: "#b23a48", lineWidth: 3 } });
+  Composite.add(
+    rope,
+    Constraint.create({
+      pointA: { x: GEO.BELL.x, y: ropeTopY },
+      bodyB: rope.bodies[0],
+      pointB: { x: 0, y: -GEO.ROPE.segH / 2 },
+      stiffness: 0.95,
+      length: 0,
+      render: { strokeStyle: "#b23a48", lineWidth: 3 },
+    })
+  );
+  // 先端の房(掴む対象。大きめにして掴みやすく)
+  const tassel = Bodies.circle(GEO.BELL.x, ropeTopY + GEO.ROPE.segs * GEO.ROPE.segH + GEO.ROPE.tasselR, GEO.ROPE.tasselR, {
+    collisionFilter: ropeFilter,
+    density: 0.004,
+    render: { fillStyle: "#e8c86a" },
+  });
+  Composite.add(rope, tassel);
+  Composite.add(
+    rope,
+    Constraint.create({
+      bodyA: rope.bodies[GEO.ROPE.segs - 1],
+      pointA: { x: 0, y: GEO.ROPE.segH / 2 },
+      bodyB: tassel,
+      pointB: { x: 0, y: -GEO.ROPE.tasselR },
+      stiffness: 0.95,
+      length: 0,
+      render: { strokeStyle: "#b23a48", lineWidth: 3 },
+    })
+  );
+  add(rope);
+
+  // 斜面A(右下がり)
+  add(Bodies.rectangle(GEO.RAMP_A.x, GEO.RAMP_A.y, GEO.RAMP_A.w, GEO.RAMP_A.h, { isStatic: true, angle: GEO.RAMP_A.angle, chamfer: { radius: 5 }, render: wood }));
+
+  // 吊り絵馬(振り子)。斜面Aの上に吊るす。下端は路面から数px浮かせ、
+  // 玉(r11)が必ず当たって揺らしていくようにする。
+  const rampSurfY = (x) => GEO.RAMP_A.y + Math.tan(GEO.RAMP_A.angle) * (x - GEO.RAMP_A.x) - GEO.RAMP_A.h / 2;
+  for (const x of GEO.EMA.xs) {
+    const bottomY = rampSurfY(x) - 4;
+    const cy = bottomY - GEO.EMA.h / 2;
+    const pivotY = cy - GEO.EMA.h / 2 - GEO.EMA.hang;
+    const plaque = Bodies.rectangle(x, cy, GEO.EMA.w, GEO.EMA.h, {
+      density: GEO.EMA.density,
+      frictionAir: 0.02,
+      label: "ema",
+      chamfer: { radius: 3 },
+      render: { fillStyle: "#e8ddc8" },
+    });
+    add(plaque);
+    add(Constraint.create({
+      pointA: { x, y: pivotY },
+      bodyB: plaque,
+      pointB: { x: 0, y: -GEO.EMA.h / 2 },
+      length: GEO.EMA.hang,
+      stiffness: 0.9,
+      render: { strokeStyle: "#caa96a", lineWidth: 2 },
+    }));
+  }
+
+  // 水車(自由回転。玉やドミノの重みで回る)
+  const wheel = Body.create({
+    parts: [
+      Bodies.rectangle(0, 0, GEO.WHEEL.arm, GEO.WHEEL.thick, { render: { fillStyle: "#d9542e" } }),
+      Bodies.rectangle(0, 0, GEO.WHEEL.thick, GEO.WHEEL.arm, { render: { fillStyle: "#d9542e" } }),
+    ],
+    density: GEO.WHEEL.density,
+    frictionAir: GEO.WHEEL.frictionAir,
+    label: "wheel",
+    render: { fillStyle: "#d9542e" },
+  });
+  Body.setPosition(wheel, { x: GEO.WHEEL.x, y: GEO.WHEEL.y });
+  Body.setAngle(wheel, Math.PI / 4);
+  add(wheel);
+  add(Constraint.create({ pointA: { x: GEO.WHEEL.x, y: GEO.WHEEL.y }, bodyB: wheel, pointB: { x: 0, y: 0 }, length: 0, stiffness: 0.9, render: { visible: false } }));
+  add(Bodies.circle(GEO.WHEEL.x, GEO.WHEEL.y, 6, { isStatic: true, render: { fillStyle: "#7a2a12" } }));
+
+  // 斜面B(左下がり)
+  add(Bodies.rectangle(GEO.RAMP_B.x, GEO.RAMP_B.y, GEO.RAMP_B.w, GEO.RAMP_B.h, { isStatic: true, angle: GEO.RAMP_B.angle, chamfer: { radius: 5 }, render: wood }));
+
+  // バンパー(弾む)
+  add(Bodies.circle(GEO.BUMPER.x, GEO.BUMPER.y, GEO.BUMPER.r, { isStatic: true, restitution: GEO.BUMPER.restitution, label: "bumper", render: { fillStyle: "#4ecdc4" } }));
+  // 斜面C(右下がり・折り返し)
+  add(Bodies.rectangle(GEO.RAMP_C.x, GEO.RAMP_C.y, GEO.RAMP_C.w, GEO.RAMP_C.h, { isStatic: true, angle: GEO.RAMP_C.angle, chamfer: { radius: 5 }, render: wood }));
+
+  // 狐の寝床(台)と縁
+  add(Bodies.rectangle(GEO.FOX_PLATFORM.x, GEO.FOX_PLATFORM.y, GEO.FOX_PLATFORM.w, GEO.FOX_PLATFORM.h, { isStatic: true, chamfer: { radius: 4 }, render: wood }));
+  add(Bodies.rectangle(GEO.FOX_LIP.x, GEO.FOX_LIP.y, GEO.FOX_LIP.w, GEO.FOX_LIP.h, { isStatic: true, chamfer: { radius: 3 }, render: wood }));
+  // 狐のおしりの当たり判定(玉が直撃したら wake)
+  add(Bodies.rectangle(GEO.FOX_SENSOR.x, GEO.FOX_SENSOR.y, GEO.FOX_SENSOR.w, GEO.FOX_SENSOR.h, {
+    isStatic: true,
+    isSensor: true,
+    label: "fox-sensor",
+    render: { visible: false },
+  }));
+
+  // ビン仕切り
+  const bw = GEO.W / GEO.BIN_COUNT;
+  for (let i = 1; i < GEO.BIN_COUNT; i++) {
+    add(Bodies.rectangle(i * bw, (GEO.BIN_TOP + GEO.FLOOR_Y) / 2, 6, GEO.FLOOR_Y - GEO.BIN_TOP, { isStatic: true, chamfer: { radius: 2 }, render: { fillStyle: "#8a6a3a" } }));
+  }
+
+  return { engine, world, rope, tassel };
+}
+
+// 御神玉を生成して投入する(鈴が鳴った時に呼ぶ)。
+function spawnBall(Matter, world, vx) {
+  const b = Matter.Bodies.circle(GEO.BALL.spawnX, GEO.BALL.spawnY, GEO.BALL.r, {
+    density: GEO.BALL.density,
+    restitution: GEO.BALL.restitution,
+    friction: GEO.BALL.friction,
+    frictionAir: GEO.BALL.frictionAir,
+    label: "ball",
+    render: { fillStyle: "#f2c14e" },
+  });
+  Matter.Body.setVelocity(b, { x: typeof vx === "number" ? vx : 0.4, y: 0 });
+  Matter.World.add(world, b);
+  return b;
+}
+
+module.exports = { GEO, buildMachineWorld, spawnBall };


### PR DESCRIPTION
## 概要

dev レビューのフィードバック対応（演出 v2）。指摘と対応：

| 指摘 | 対応 |
|---|---|
| オブジェクトがタップで動かせてしまう | `MouseConstraint` を collisionFilter で**鈴の緒（房）だけ**掴めるよう制限。装置・玉は操作不可 |
| 鈴を鳴らすのがボタンになっていた | 鈴の緒を**スワイプで実際に振れる**ように（`touch-action:none`、振幅ベース判定＝中心±26px を交互に3回で鳴る）。ボタンは小さなフォールバックリンクに降格 |
| ギミックを全部通らない | 装置を `omikujiMachine.js` に切り出し **Node でヘッドレス検証**。鈴→御神玉→斜面A（吊り絵馬がカランと揺れる）→水車（玉の重みで回る）→斜面B→**バンパーでポーンと上へ跳ねて折り返し**→斜面C→狐に直撃、を全投入速度で完走確認（約12秒） |
| 玉が消えて突然狐が出る | **狐は最初から寝床で寝ている**（Zzz付き、突然現れない）。玉が物理的におしりに直撃して「!」と起きる。鳴った後も物理は残り、一続きに見える |
| 狐が顔だけ | 体・しっぽ・耳・足を持つ **SVG狐**（`FoxSprite.vue`）に。ポーズ切替（sleep/idle/crouch/jump/land/happy） |
| ジャンプが速すぎて焦らしがない | 溜め（しゃがみ・おしりフリフリ 430〜780ms）→ゆっくり跳ぶ（760〜950ms）→着地で潰れる→キョロキョロ（550〜900ms）。**本命前は溜めを長く**。着地ビンが金色に光る |
| 縦のオブジェクト（ドミノ）が謎 | 立ちドミノ廃止 →**吊り絵馬**に。玉の通り道で必ず揺れる＝ギミックとして機能 |
| 距離が短く下るだけで単調 | ジグザグ3往復＋**バンパーの上方向の跳ね**を追加 |

## 実装メモ

- 立ちドミノは matter の低速摩擦減衰で「倒れた札が玉を止める」ため吊り絵馬（振り子）に変更。シーソー案は複合ボディの重心/ピボット問題で不安定なため、玉の飛行経路（Node検証で全条件同一の帯を通過）上に狐を置く直撃方式に。
- 抽選の公平性は不変：レア度はサーバー決定、狐の最終着地ビンだけがスクリプト制御（`omikujiFox.js`、末尾＝必ずターゲットを 3400 ケースで検証済み）。装置は見せ場専用で、詰まってもタイムボックス（15s）で狐が起きる。フェイルセーフ 30s、タップスキップ、reduced-motion 対応。
- 旧 `omikujiPhysics.js`（プリシム方式）は撤去。

## 検証

- 装置完走：Node で全投入速度・儀式10秒静置つきスイープ → センサー到達 ✓（誤発火なし）
- 狐ホップ列：全7 tier × 3400 ケースで「末尾＝ターゲット・途中はおとり」✓
- `yarn generate` ✓、ヘッドレス Chromium で儀式/道中/直撃の3場面を描画確認 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_