### PR TITLE
おみくじ結果にコピペ共有用テキスト(ShareText)を追加

### DIFF
--- a/web/pages/omikuji.vue
+++ b/web/pages/omikuji.vue
@@ -39,6 +39,11 @@
         次に引けるまで <span class="fw-bold">{{ remainingText }}</span>
       </div>
 
+      <!-- コピペ用テキスト(参拝結果と同じUI) -->
+      <div class="my-5 mx-auto" style="max-width: 600px">
+        <ShareText title="SNSで自慢しよう" :text="shareText"></ShareText>
+      </div>
+
       <div class="mt-4">
         <Share
           title="おみくじの結果をSNSで報告しよう"
@@ -218,6 +223,27 @@ export default {
     shareMessage() {
       if (!this.result) return "でばっぐ神社でおみくじを引いたよ。";
       return `でばっぐ神社のITおみくじは【${this.result.tier}】「${this.result.fortune}」でした。`;
+    },
+    // コピペ用の全文(参拝の shareText と同じ流儀)。項目ごとの文章まで含める。
+    shareText() {
+      if (!this.result) return "";
+      const emoji = {
+        超吉: "🌟",
+        大吉: "🎉",
+        中吉: "😊",
+        小吉: "🙂",
+        末吉: "😌",
+        凶: "😰",
+        大凶: "💀",
+      }[this.result.tier] || "🔮";
+      const lines = [
+        `⛩️でばっぐ神社のITおみくじは${emoji}【${this.result.tier}】でした`,
+        `「${this.result.fortune}」`,
+        ...(this.result.lines || []).map((l) => `・${l.category}: ${l.text}`),
+        "#でばっぐ神社",
+        this.shareUrl,
+      ];
+      return lines.join("\n");
     },
   },
 };


### PR DESCRIPTION
## 概要

参拝結果と同じUI(`ShareText`)で、おみくじの結果をワンクリックでクリップボードにコピーできるようにする。

## 変更内容(`web/pages/omikuji.vue` のみ)

- 結果表示ブロックに `ShareText`(コピペ用テキストエリア+コピーボタン)を追加。既存のSNS共有ボタン(`Share`)はそのまま
- `shareText` computed を追加。整形フォーマット:

```
⛩️でばっぐ神社のITおみくじは💀【大凶】でした
「金曜17時、本番リリースの待機が決定。」
・デプロイ運: ロールバック手順を今のうちに音読しておけ。
・健康運: モニターの光だけで一日が終わる。
#でばっぐ神社
https://d-shrine.jp
```

- レア度ごとの絵文字(🌟🎉😊🙂😌😰💀)付き。項目ごとの文章まで全文含める(1件3〜4項目なので長すぎない)
- テキストエリアは編集可能なので、コピー前に手直しもできる(ShareText既存仕様)

## 検証

- `yarn generate` 成功
- 整形ロジックはNodeで出力確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_