### PR TITLE
参拝の草(GitHub風ヒートマップ)を追加

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -265,6 +265,8 @@ jobs:
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           deploy rankingGo RankingGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
+          deploy sanpaiHistoryGo SanpaiHistoryGo \
+            --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           deploy omikujiGo OmikujiGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s \
             --set-env-vars="OMIKUJI_COOLDOWN_SECONDS=60"

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -213,6 +213,8 @@ jobs:
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           deploy rankingGo RankingGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
+          deploy sanpaiHistoryGo SanpaiHistoryGo \
+            --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           deploy omikujiGo OmikujiGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s \
             --set-env-vars="OMIKUJI_COOLDOWN_SECONDS=28800"

--- a/app/firebase.json
+++ b/app/firebase.json
@@ -20,6 +20,10 @@
         "function": "rankingGo"
       },
       {
+        "source": "/sanpaiHistoryGo",
+        "function": "sanpaiHistoryGo"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/app/functions-go/sanpai_history.go
+++ b/app/functions-go/sanpai_history.go
@@ -1,0 +1,214 @@
+// 参拝履歴(草グラフ用)エンドポイント。
+//
+// 参拝成功時に書かれる users/{github_id}/sanpai_logs({add_point, timestamp})を
+// JSTの日毎に集計して返す。GitHubのコントリビューショングラフ風の表示
+// (web/components/SanpaiGrass.vue)のデータ源。
+//
+//	GET ?user={screen_name}        … 直近371日(53週)分
+//	GET ?user={screen_name}&all=1  … 全期間(最古のログから現在まで)
+//
+// 集計済みの日別データのみ返すためレスポンスは全期間でも小さいが、
+// all=1 はFirestoreの読み取りが履歴全量になるため、フロントエンドでは
+// 明示的な「全期間を解析する」操作でのみ呼ぶ(詳細は docs/backend.md)。
+package gofunctions
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"sort"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+	"google.golang.org/api/iterator"
+)
+
+func init() {
+	functions.HTTP("SanpaiHistoryGo", sanpaiHistoryHandler)
+}
+
+// 参拝履歴の集計はサイトの利用者がほぼ日本在住である前提でJST固定で日を切る。
+// (UTCで切ると日本の朝9時前の参拝が前日扱いになり草の位置がずれる)
+var jstLocation = time.FixedZone("JST", 9*60*60)
+
+// defaultHistoryDays はデフォルト表示(直近1年)の日数。53週=371日。
+const defaultHistoryDays = 371
+
+type sanpaiHistoryDay struct {
+	Date   string `json:"date"` // "YYYY-MM-DD"(JST)
+	Count  int    `json:"count"`
+	Points int64  `json:"points"`
+}
+
+type sanpaiHistoryResponse struct {
+	Days        []sanpaiHistoryDay `json:"days"` // 参拝があった日のみ(昇順)
+	TotalCount  int                `json:"total_count"`
+	TotalPoints int64              `json:"total_points"`
+	FirstSanpai string             `json:"first_sanpai,omitempty"` // all=1時のみ: 最古の参拝日
+	Since       string             `json:"since"`
+	Until       string             `json:"until"`
+}
+
+// sanpaiLogEntry は sanpai_logs ドキュメントのうち集計に使う部分。
+type sanpaiLogEntry struct {
+	AddPoint  int64     `firestore:"add_point"`
+	Timestamp time.Time `firestore:"timestamp"`
+}
+
+func sanpaiHistoryHandler(w http.ResponseWriter, r *http.Request) {
+	setCORSHeaders(w, r)
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Access-Control-Allow-Methods", "GET,OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type,Authorization")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	screenName := r.URL.Query().Get("user")
+	if screenName == "" {
+		writeError(w, http.StatusBadRequest, "user is required")
+		return
+	}
+	all := r.URL.Query().Get("all") == "1"
+
+	ctx := r.Context()
+	client, err := getFirestoreClient(ctx)
+	if err != nil {
+		log.Printf("sanpaiHistory: getFirestoreClient error: %v", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	if err := runSanpaiHistory(ctx, w, client, screenName, all, time.Now()); err != nil {
+		log.Printf("sanpaiHistory: %v", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+	}
+}
+
+// runSanpaiHistory は本体。now を引数にしているのはテストで時刻を固定するため。
+func runSanpaiHistory(ctx context.Context, w http.ResponseWriter, client *firestore.Client, screenName string, all bool, now time.Time) error {
+	userDoc, err := findUserByScreenName(ctx, client, screenName)
+	if err != nil {
+		return err
+	}
+	if userDoc == nil {
+		writeError(w, http.StatusNotFound, "user not registered.")
+		return nil
+	}
+
+	today := startOfDayJST(now)
+	query := userDoc.Ref.Collection("sanpai_logs").Query
+	var since time.Time
+	if !all {
+		// 直近371日(今日を含む)。開始日のJST 0:00以降のログだけを読む。
+		since = today.AddDate(0, 0, -(defaultHistoryDays - 1))
+		query = query.Where("timestamp", ">=", since)
+	}
+
+	entries, err := loadSanpaiLogs(ctx, query)
+	if err != nil {
+		return err
+	}
+
+	days := aggregateSanpaiDays(entries, jstLocation)
+	resp := sanpaiHistoryResponse{
+		Days:  days,
+		Until: formatDateJST(today),
+	}
+	for _, d := range days {
+		resp.TotalCount += d.Count
+		resp.TotalPoints += d.Points
+	}
+	if all {
+		// 全期間: 開始は最古の参拝日(ログが無ければ今日)。
+		if len(days) > 0 {
+			resp.Since = days[0].Date
+			resp.FirstSanpai = days[0].Date
+		} else {
+			resp.Since = resp.Until
+		}
+	} else {
+		resp.Since = formatDateJST(since)
+	}
+
+	setSanpaiHistoryCacheHeaders(w, all)
+	writeJSON(w, http.StatusOK, resp)
+	return nil
+}
+
+// setSanpaiHistoryCacheHeaders は参拝履歴応答のキャッシュ方針を設定する。
+//
+// 参拝履歴は公開プロフィール(/u/{userName})にも出す公開データで、URLが
+// user と all でキー分離されるためCDNの共有キャッシュに載せられる
+// (ランキングのグローバル応答と同じ考え方。ranking.go 参照)。
+//
+// デフォルト(直近1年)は参拝直後に草が生えるのが見えてほしいので短め。
+// 全期間(all=1)は過去分がほぼ不変・明示操作でしか呼ばれないため長めにして
+// 全量読み取りの再実行を抑える。
+func setSanpaiHistoryCacheHeaders(w http.ResponseWriter, all bool) {
+	if all {
+		w.Header().Set("Cache-Control", "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400")
+		return
+	}
+	w.Header().Set("Cache-Control", "public, max-age=60, s-maxage=300, stale-while-revalidate=600")
+}
+
+func loadSanpaiLogs(ctx context.Context, query firestore.Query) ([]sanpaiLogEntry, error) {
+	iter := query.Documents(ctx)
+	defer iter.Stop()
+	var entries []sanpaiLogEntry
+	for {
+		doc, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		var e sanpaiLogEntry
+		if err := doc.DataTo(&e); err != nil {
+			return nil, err
+		}
+		entries = append(entries, e)
+	}
+	return entries, nil
+}
+
+// aggregateSanpaiDays は参拝ログを loc の日付で日毎に集計する(純関数)。
+// 返り値は日付昇順で、参拝があった日のみ含む(0の日はフロントエンドが埋める)。
+func aggregateSanpaiDays(entries []sanpaiLogEntry, loc *time.Location) []sanpaiHistoryDay {
+	byDate := map[string]*sanpaiHistoryDay{}
+	for _, e := range entries {
+		if e.Timestamp.IsZero() {
+			continue
+		}
+		date := e.Timestamp.In(loc).Format("2006-01-02")
+		d, ok := byDate[date]
+		if !ok {
+			d = &sanpaiHistoryDay{Date: date}
+			byDate[date] = d
+		}
+		d.Count++
+		d.Points += e.AddPoint
+	}
+
+	days := make([]sanpaiHistoryDay, 0, len(byDate))
+	for _, d := range byDate {
+		days = append(days, *d)
+	}
+	// "YYYY-MM-DD" は辞書順 == 日付順。
+	sort.Slice(days, func(i, j int) bool { return days[i].Date < days[j].Date })
+	return days
+}
+
+// startOfDayJST は now のJSTでの日付の 0:00(JST)を返す。
+func startOfDayJST(now time.Time) time.Time {
+	t := now.In(jstLocation)
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, jstLocation)
+}
+
+func formatDateJST(t time.Time) string {
+	return t.In(jstLocation).Format("2006-01-02")
+}

--- a/app/functions-go/sanpai_history_integration_test.go
+++ b/app/functions-go/sanpai_history_integration_test.go
@@ -1,0 +1,147 @@
+package gofunctions
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/firestore"
+)
+
+// Firestore エミュレータが必要(FIRESTORE_EMULATOR_HOST 未設定時は自動スキップ)。
+
+func decodeHistoryResp(t *testing.T, rec *httptest.ResponseRecorder) sanpaiHistoryResponse {
+	t.Helper()
+	var resp sanpaiHistoryResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v (body=%s)", err, rec.Body.String())
+	}
+	return resp
+}
+
+func seedSanpaiLog(t *testing.T, userRef *firestore.DocumentRef, ts time.Time, addPoint int64) {
+	t.Helper()
+	if _, _, err := userRef.Collection("sanpai_logs").Add(context.Background(), map[string]interface{}{
+		"add_point": addPoint,
+		"timestamp": ts,
+	}); err != nil {
+		t.Fatalf("seed sanpai_log: %v", err)
+	}
+}
+
+func TestSanpaiHistory_DefaultAndAll(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	uid := "sanpai-history-test-user-1"
+	userRef := client.Collection("users").Doc(uid)
+	if _, err := userRef.Set(ctx, map[string]interface{}{"screen_name": "history-tester"}); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		iter := userRef.Collection("sanpai_logs").Documents(context.Background())
+		for {
+			doc, err := iter.Next()
+			if err != nil {
+				break
+			}
+			doc.Ref.Delete(context.Background())
+		}
+		userRef.Delete(context.Background())
+	})
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, jstLocation)
+	// 直近期間内: 同日2回 + 別日1回
+	seedSanpaiLog(t, userRef, time.Date(2026, 7, 9, 9, 0, 0, 0, jstLocation), 5)
+	seedSanpaiLog(t, userRef, time.Date(2026, 7, 9, 21, 0, 0, 0, jstLocation), 7)
+	seedSanpaiLog(t, userRef, time.Date(2026, 7, 1, 10, 0, 0, 0, jstLocation), 3)
+	// 期間外(4年前 = 全期間でのみ現れる)
+	seedSanpaiLog(t, userRef, time.Date(2022, 1, 2, 10, 0, 0, 0, jstLocation), 11)
+
+	// 1) デフォルト(直近371日): 期間外の2022年ログは含まれない
+	rec := httptest.NewRecorder()
+	if err := runSanpaiHistory(ctx, rec, client, "history-tester", false, now); err != nil {
+		t.Fatalf("runSanpaiHistory default: %v", err)
+	}
+	resp := decodeHistoryResp(t, rec)
+	if len(resp.Days) != 2 {
+		t.Fatalf("default days = %d (%+v), want 2", len(resp.Days), resp.Days)
+	}
+	if resp.Days[0].Date != "2026-07-01" || resp.Days[1].Date != "2026-07-09" {
+		t.Errorf("default days order = %+v", resp.Days)
+	}
+	if resp.Days[1].Count != 2 || resp.Days[1].Points != 12 {
+		t.Errorf("7/9 = %+v, want count=2 points=12", resp.Days[1])
+	}
+	if resp.TotalCount != 3 || resp.TotalPoints != 15 {
+		t.Errorf("default totals = %d/%d, want 3/15", resp.TotalCount, resp.TotalPoints)
+	}
+	if resp.Until != "2026-07-10" {
+		t.Errorf("until = %q, want 2026-07-10", resp.Until)
+	}
+	if resp.FirstSanpai != "" {
+		t.Errorf("default first_sanpai = %q, want empty", resp.FirstSanpai)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "public, max-age=60, s-maxage=300, stale-while-revalidate=600" {
+		t.Errorf("default Cache-Control = %q", got)
+	}
+
+	// 2) 全期間(all=1): 2022年のログも含まれ、since/first_sanpai が最古日
+	rec = httptest.NewRecorder()
+	if err := runSanpaiHistory(ctx, rec, client, "history-tester", true, now); err != nil {
+		t.Fatalf("runSanpaiHistory all: %v", err)
+	}
+	respAll := decodeHistoryResp(t, rec)
+	if len(respAll.Days) != 3 {
+		t.Fatalf("all days = %d (%+v), want 3", len(respAll.Days), respAll.Days)
+	}
+	if respAll.Days[0].Date != "2022-01-02" {
+		t.Errorf("all first day = %+v, want 2022-01-02", respAll.Days[0])
+	}
+	if respAll.Since != "2022-01-02" || respAll.FirstSanpai != "2022-01-02" {
+		t.Errorf("all since/first = %q/%q, want 2022-01-02", respAll.Since, respAll.FirstSanpai)
+	}
+	if respAll.TotalCount != 4 || respAll.TotalPoints != 26 {
+		t.Errorf("all totals = %d/%d, want 4/26", respAll.TotalCount, respAll.TotalPoints)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400" {
+		t.Errorf("all Cache-Control = %q", got)
+	}
+}
+
+func TestSanpaiHistory_EmptyLogsAndUnknownUser(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, jstLocation)
+
+	uid := "sanpai-history-test-user-2"
+	userRef := client.Collection("users").Doc(uid)
+	if _, err := userRef.Set(ctx, map[string]interface{}{"screen_name": "history-empty"}); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() { userRef.Delete(context.Background()) })
+
+	// ログなしユーザー: days は空配列、totalは0
+	rec := httptest.NewRecorder()
+	if err := runSanpaiHistory(ctx, rec, client, "history-empty", true, now); err != nil {
+		t.Fatalf("runSanpaiHistory empty: %v", err)
+	}
+	resp := decodeHistoryResp(t, rec)
+	if len(resp.Days) != 0 || resp.TotalCount != 0 {
+		t.Errorf("empty user resp = %+v", resp)
+	}
+	if resp.Since != "2026-07-10" || resp.Until != "2026-07-10" {
+		t.Errorf("empty since/until = %q/%q", resp.Since, resp.Until)
+	}
+
+	// 未登録ユーザー: 404
+	rec = httptest.NewRecorder()
+	if err := runSanpaiHistory(ctx, rec, client, "no-such-user-history", false, now); err != nil {
+		t.Fatalf("runSanpaiHistory unknown: %v", err)
+	}
+	if rec.Code != 404 {
+		t.Errorf("unknown user status = %d, want 404", rec.Code)
+	}
+}

--- a/app/functions-go/sanpai_history_test.go
+++ b/app/functions-go/sanpai_history_test.go
@@ -1,0 +1,90 @@
+package gofunctions
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestAggregateSanpaiDays_Empty(t *testing.T) {
+	days := aggregateSanpaiDays(nil, jstLocation)
+	if len(days) != 0 {
+		t.Fatalf("empty entries → %d days, want 0", len(days))
+	}
+}
+
+func TestAggregateSanpaiDays_JSTBoundary(t *testing.T) {
+	// UTC 2026-07-09 15:00 = JST 2026-07-10 00:00 → JSTでは7/10扱い。
+	// UTC 2026-07-09 14:59 = JST 2026-07-09 23:59 → 7/9扱い。
+	entries := []sanpaiLogEntry{
+		{Timestamp: time.Date(2026, 7, 9, 14, 59, 0, 0, time.UTC), AddPoint: 3},
+		{Timestamp: time.Date(2026, 7, 9, 15, 0, 0, 0, time.UTC), AddPoint: 5},
+	}
+	days := aggregateSanpaiDays(entries, jstLocation)
+	if len(days) != 2 {
+		t.Fatalf("days = %d, want 2 (JST境界で別日に分かれる)", len(days))
+	}
+	if days[0].Date != "2026-07-09" || days[0].Count != 1 || days[0].Points != 3 {
+		t.Errorf("day0 = %+v, want 2026-07-09 count=1 points=3", days[0])
+	}
+	if days[1].Date != "2026-07-10" || days[1].Count != 1 || days[1].Points != 5 {
+		t.Errorf("day1 = %+v, want 2026-07-10 count=1 points=5", days[1])
+	}
+}
+
+func TestAggregateSanpaiDays_MultiplePerDayAndSorted(t *testing.T) {
+	jst := jstLocation
+	entries := []sanpaiLogEntry{
+		// 入力順は意図的にバラバラ。年跨ぎも含む。
+		{Timestamp: time.Date(2026, 1, 1, 9, 0, 0, 0, jst), AddPoint: 2},
+		{Timestamp: time.Date(2025, 12, 31, 23, 0, 0, 0, jst), AddPoint: 10},
+		{Timestamp: time.Date(2026, 1, 1, 21, 0, 0, 0, jst), AddPoint: 4},
+		{Timestamp: time.Date(2026, 1, 1, 12, 0, 0, 0, jst), AddPoint: 1},
+	}
+	days := aggregateSanpaiDays(entries, jst)
+	if len(days) != 2 {
+		t.Fatalf("days = %d, want 2", len(days))
+	}
+	if days[0].Date != "2025-12-31" || days[0].Count != 1 || days[0].Points != 10 {
+		t.Errorf("day0 = %+v, want 2025-12-31 count=1 points=10", days[0])
+	}
+	if days[1].Date != "2026-01-01" || days[1].Count != 3 || days[1].Points != 7 {
+		t.Errorf("day1 = %+v, want 2026-01-01 count=3 points=7", days[1])
+	}
+}
+
+func TestAggregateSanpaiDays_SkipsZeroTimestamp(t *testing.T) {
+	entries := []sanpaiLogEntry{
+		{Timestamp: time.Time{}, AddPoint: 5},
+		{Timestamp: time.Date(2026, 7, 10, 10, 0, 0, 0, jstLocation), AddPoint: 3},
+	}
+	days := aggregateSanpaiDays(entries, jstLocation)
+	if len(days) != 1 || days[0].Date != "2026-07-10" {
+		t.Fatalf("days = %+v, want only 2026-07-10", days)
+	}
+}
+
+func TestStartOfDayJST(t *testing.T) {
+	// UTC 2026-07-09 20:00 = JST 2026-07-10 05:00 → JSTの7/10 0:00になるはず。
+	got := startOfDayJST(time.Date(2026, 7, 9, 20, 0, 0, 0, time.UTC))
+	want := time.Date(2026, 7, 10, 0, 0, 0, 0, jstLocation)
+	if !got.Equal(want) {
+		t.Errorf("startOfDayJST = %v, want %v", got, want)
+	}
+}
+
+func TestSetSanpaiHistoryCacheHeaders(t *testing.T) {
+	for _, tc := range []struct {
+		all  bool
+		want string
+	}{
+		{false, "public, max-age=60, s-maxage=300, stale-while-revalidate=600"},
+		{true, "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400"},
+	} {
+		rec := httptest.NewRecorder()
+		setSanpaiHistoryCacheHeaders(rec, tc.all)
+		if got := rec.Header().Get("Cache-Control"); got != tc.want {
+			t.Errorf("all=%v Cache-Control = %q, want %q", tc.all, got, tc.want)
+		}
+	}
+}

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -455,3 +455,46 @@ Node版との差分(意図的な改善):
 
 - `omikujiGo` は HTTP 関数として dev/prod 両ワークフローでデプロイ(`sanpaiGo` と同型。
   GitHub認証情報は不要)。POST のため Hosting rewrite は付けず、フロントは関数を直叩きする。
+
+## 参拝履歴(草グラフ)エンドポイント sanpaiHistoryGo
+
+ユーザーページをポートフォリオとして使えるようにする取り組みの第一弾。
+参拝履歴を GitHub のコントリビューショングラフ風のヒートマップ(草)で表示する。
+
+### データ源と集計
+
+- 参拝成功時に書かれる `users/{github_id}/sanpai_logs`(`add_point`, `timestamp`)を
+  読み取り専用で集計する(**新規の書き込みは追加していない**。過去分の履歴が
+  そのまま草になる)。expire/noaction の参拝はログが無いため草にならない
+  (=実りのある参拝だけが生える)。
+- 日付は **JST固定** で切る(`app/functions-go/sanpai_history.go` の
+  `aggregateSanpaiDays`。純関数でユニットテスト済み)。
+- レスポンスは日別集計(`{date, count, points}` の昇順配列)のみで、
+  全期間でも高々1800日分程度と小さい。
+
+### API
+
+- `GET sanpaiHistoryGo?user={screen_name}` … 直近371日(53週)。
+  `timestamp >= 開始日` の範囲クエリのみで読む量を抑える。
+- `GET sanpaiHistoryGo?user={screen_name}&all=1` … 全期間(最古のログから)。
+  履歴全量の読み取りが走るため、フロントは**明示的な「全期間を解析する」
+  ボタンでのみ**呼ぶ(2021/12/31リリースから約5年分の履歴がある)。
+
+### キャッシュ(ranking と同じ方針)
+
+- 公開データで URL が `user`/`all` でキー分離されるため CDN の共有キャッシュに載せる。
+  `app/firebase.json` に `/sanpaiHistoryGo` の Hosting rewrite を追加し、フロントは
+  `rankingBaseUrl || apiUrl` 経由で取得(ranking.vue と同型)。
+- デフォルト: `public, max-age=60, s-maxage=300, stale-while-revalidate=600`
+  (参拝直後に草が生えるのが見えるよう短め)。
+- 全期間: `public, max-age=300, s-maxage=3600, stale-while-revalidate=86400`
+  (過去分はほぼ不変・重い読み取りの再実行を抑える)。
+
+### フロント
+
+- `web/components/sanpaiGrass.js` … 週折り返し・月ラベル・年分割の純関数
+  (Node で決定論的に検証。omikujiFox.js と同じ流儀)。
+- `web/components/GrassGrid.vue` … 1期間分のグリッド描画(直近1年と年別表示で共用。
+  チャートライブラリ不使用のCSSグリッド)。
+- `web/components/SanpaiGrass.vue` … 取得と状態管理。直近1年+「全期間を解析する」
+  ボタンで年ごとの草を縦に並べる。設置場所は `/u/{userName}`(公開)と `/dashboard`。

--- a/web/components/GrassGrid.vue
+++ b/web/components/GrassGrid.vue
@@ -1,0 +1,158 @@
+<template>
+  <div class="grass-scroll" ref="scroll">
+    <div class="grass-inner">
+      <!-- 月ラベル(週の列位置に合わせて絶対配置) -->
+      <div class="month-row" :style="{ width: cellsWidth + 'px' }">
+        <span
+          v-for="m in grid.monthLabels"
+          :key="m.week + '-' + m.label"
+          class="month-label"
+          :style="{ left: m.week * pitch + 'px' }"
+          >{{ m.label }}</span
+        >
+      </div>
+      <div class="grid-row">
+        <!-- 曜日ラベル(月・水・金のみ表示) -->
+        <div class="weekday-col">
+          <span v-for="(w, i) in weekdays" :key="i" class="weekday">{{
+            w
+          }}</span>
+        </div>
+        <!-- 週=列、日=行 -->
+        <div class="weeks">
+          <div v-for="(week, wi) in grid.weeks" :key="wi" class="week-col">
+            <span
+              v-for="cell in week"
+              :key="cell.date"
+              class="cell"
+              :class="cell.inRange ? 'lv-' + levelFor(cell.count) : 'lv-out'"
+              :title="cellTitle(cell)"
+            ></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+// 1つの草グリッド(期間分)を描画する。直近1年と年別表示(全期間)で共用。
+const { buildGrassGrid, levelFor } = require("@/components/sanpaiGrass");
+
+export default {
+  props: {
+    since: { type: String, required: true }, // "YYYY-MM-DD"
+    until: { type: String, required: true },
+    days: { type: Array, default: () => [] }, // [{date, count, points}]
+  },
+  data() {
+    return {
+      // セル11px + 隙間3px。月ラベルの位置計算(CSSと合わせる)に使う。
+      pitch: 14,
+      weekdays: ["", "月", "", "水", "", "金", ""],
+    };
+  },
+  computed: {
+    grid() {
+      return buildGrassGrid(this.since, this.until, this.days);
+    },
+    cellsWidth() {
+      return this.grid.weeks.length * this.pitch;
+    },
+  },
+  mounted() {
+    // 直近(右端)が見える位置から始める(モバイルで左端=1年前始まりだと
+    // 最初に見えるのが古い草になってしまう)。
+    this.$refs.scroll.scrollLeft = this.$refs.scroll.scrollWidth;
+  },
+  methods: {
+    levelFor,
+    cellTitle(cell) {
+      if (!cell.inRange) return "";
+      if (cell.count <= 0) return `${cell.date}: 参拝なし`;
+      return `${cell.date}: ${cell.count}回参拝 (+${cell.points}pt)`;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.grass-scroll {
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+.grass-inner {
+  display: inline-block;
+}
+
+/* 月ラベル */
+.month-row {
+  position: relative;
+  height: 16px;
+  margin-left: 26px; /* 曜日ラベル幅ぶん */
+}
+.month-label {
+  position: absolute;
+  top: 0;
+  font-size: 10px;
+  color: #9a9a9a;
+  white-space: nowrap;
+}
+
+.grid-row {
+  display: flex;
+}
+
+/* 曜日ラベル */
+.weekday-col {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  width: 26px;
+  flex: 0 0 auto;
+}
+.weekday {
+  height: 11px;
+  line-height: 11px;
+  font-size: 10px;
+  color: #9a9a9a;
+}
+
+/* 草本体 */
+.weeks {
+  display: flex;
+  gap: 3px;
+}
+.week-col {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.cell {
+  width: 11px;
+  height: 11px;
+  border-radius: 2px;
+  flex: 0 0 auto;
+}
+/* 濃淡はGitHubのダークテーマ準拠(サイト背景が暗いため) */
+.lv-out {
+  background: transparent;
+}
+.lv-0 {
+  background: #1b2028;
+  outline: 1px solid rgba(255, 255, 255, 0.05);
+  outline-offset: -1px;
+}
+.lv-1 {
+  background: #0e4429;
+}
+.lv-2 {
+  background: #006d32;
+}
+.lv-3 {
+  background: #26a641;
+}
+.lv-4 {
+  background: #39d353;
+}
+</style>

--- a/web/components/SanpaiGrass.vue
+++ b/web/components/SanpaiGrass.vue
@@ -1,0 +1,220 @@
+<template>
+  <div class="sanpai-grass p-3 rounded">
+    <div class="d-flex justify-content-between align-items-center flex-wrap mb-2">
+      <div class="grass-title">⛩️ 参拝の草</div>
+      <div v-if="state === 'loaded'" class="grass-sub">
+        直近1年: {{ recent.totalCount }}回参拝
+      </div>
+    </div>
+
+    <!-- 直近1年 -->
+    <div v-if="state === 'loading'" class="grass-sub py-3">
+      草を数えています<span class="dots"></span>
+    </div>
+    <div v-else-if="state === 'error'" class="py-2">
+      <span class="grass-sub">参拝履歴を読み込めませんでした。</span>
+      <button class="btn btn-sm btn-outline-light ms-2" @click="fetchRecent">
+        再読み込み
+      </button>
+    </div>
+    <template v-else>
+      <GrassGrid
+        :since="recent.since"
+        :until="recent.until"
+        :days="recent.days"
+      />
+      <div class="d-flex justify-content-end align-items-center mt-1 legend">
+        <span class="grass-sub me-1">少</span>
+        <span v-for="lv in [0, 1, 2, 3, 4]" :key="lv" class="legend-cell" :class="'lv-' + lv"></span>
+        <span class="grass-sub ms-1">多</span>
+      </div>
+
+      <!-- 全期間(明示的な解析ボタンでのみ取得。5年分の読み取りが走るため) -->
+      <div class="mt-3">
+        <button
+          v-if="allState === 'idle'"
+          class="btn btn-sm btn-outline-light"
+          @click="loadAll"
+        >
+          📜 全期間を解析する
+        </button>
+        <div v-else-if="allState === 'loading'" class="grass-sub py-2">
+          全期間の参拝を解析しています<span class="dots"></span>
+        </div>
+        <div v-else-if="allState === 'error'" class="py-2">
+          <span class="grass-sub">全期間の解析に失敗しました。</span>
+          <button class="btn btn-sm btn-outline-light ms-2" @click="loadAll">
+            もう一度
+          </button>
+        </div>
+        <template v-else>
+          <div class="all-summary rounded p-2 mb-3">
+            <span class="me-3">初参拝: <strong>{{ all.firstSanpai || "-" }}</strong></span>
+            <span class="me-3">累計参拝: <strong>{{ all.totalCount }}回</strong></span>
+            <span>累計獲得: <strong>{{ all.totalPoints.toLocaleString() }}pt</strong></span>
+          </div>
+          <div v-if="allYears.length === 0" class="grass-sub">
+            まだ参拝の記録がありません。
+          </div>
+          <div v-for="y in allYears" :key="y.year" class="mb-3">
+            <div class="grass-sub mb-1">
+              {{ y.year }}年 <span class="ms-2">{{ y.count }}回参拝</span>
+            </div>
+            <GrassGrid :since="y.since" :until="y.until" :days="y.days" />
+          </div>
+        </template>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script>
+// 参拝履歴のヒートマップ(草)。sanpaiHistoryGo から日別集計を取得して表示する。
+// デフォルトは直近1年、「全期間を解析する」ボタンで初参拝まで遡って年別に出す。
+import GrassGrid from "@/components/GrassGrid";
+const { splitYearRanges } = require("@/components/sanpaiGrass");
+
+export default {
+  components: { GrassGrid },
+  props: {
+    screenName: { type: String, required: true },
+  },
+  data() {
+    return {
+      state: "loading", // loading | loaded | error
+      recent: { days: [], totalCount: 0, since: "", until: "" },
+      allState: "idle", // idle | loading | loaded | error
+      all: { firstSanpai: "", totalCount: 0, totalPoints: 0 },
+      allYears: [], // [{year, since, until, days, count}]
+    };
+  },
+  async mounted() {
+    await this.fetchRecent();
+  },
+  methods: {
+    // 取得先は rankingGo と同じく Hosting CDN オリジン(rankingBaseUrl)を優先し、
+    // 公開データをエッジでキャッシュさせる。未設定なら関数直叩きにフォールバック。
+    async fetchHistory(params) {
+      const res = await this.$axios.get("/sanpaiHistoryGo", {
+        baseURL: this.$config.rankingBaseUrl || this.$config.apiUrl,
+        params: params,
+      });
+      return res.data;
+    },
+    async fetchRecent() {
+      this.state = "loading";
+      try {
+        const d = await this.fetchHistory({ user: this.screenName });
+        this.recent = {
+          days: d.days || [],
+          totalCount: d.total_count || 0,
+          since: d.since,
+          until: d.until,
+        };
+        this.state = "loaded";
+      } catch (e) {
+        this.state = "error";
+      }
+    },
+    async loadAll() {
+      this.allState = "loading";
+      try {
+        const d = await this.fetchHistory({ user: this.screenName, all: 1 });
+        const days = d.days || [];
+        this.all = {
+          firstSanpai: d.first_sanpai || "",
+          totalCount: d.total_count || 0,
+          totalPoints: d.total_points || 0,
+        };
+        if (days.length > 0) {
+          this.allYears = splitYearRanges(d.first_sanpai || d.since, d.until).map(
+            (range) => {
+              const prefix = range.year + "-";
+              const yearDays = days.filter((day) => day.date.indexOf(prefix) === 0);
+              return {
+                year: range.year,
+                since: range.since,
+                until: range.until,
+                days: yearDays,
+                count: yearDays.reduce((sum, day) => sum + day.count, 0),
+              };
+            }
+          );
+        } else {
+          this.allYears = [];
+        }
+        this.allState = "loaded";
+      } catch (e) {
+        this.allState = "error";
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.sanpai-grass {
+  background: #0d1117;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+.grass-title {
+  font-weight: 700;
+}
+.grass-sub {
+  color: #9a9a9a;
+  font-size: 0.85rem;
+}
+.all-summary {
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.9rem;
+}
+
+/* 凡例(GrassGridのセルと同じ配色) */
+.legend-cell {
+  width: 11px;
+  height: 11px;
+  border-radius: 2px;
+  margin: 0 1.5px;
+  display: inline-block;
+}
+.legend-cell.lv-0 {
+  background: #1b2028;
+  outline: 1px solid rgba(255, 255, 255, 0.05);
+  outline-offset: -1px;
+}
+.legend-cell.lv-1 {
+  background: #0e4429;
+}
+.legend-cell.lv-2 {
+  background: #006d32;
+}
+.legend-cell.lv-3 {
+  background: #26a641;
+}
+.legend-cell.lv-4 {
+  background: #39d353;
+}
+
+/* 読み込み中の「...」 */
+.dots::after {
+  content: "";
+  animation: grass-dots 1.2s steps(4, end) infinite;
+}
+@keyframes grass-dots {
+  0% {
+    content: "";
+  }
+  25% {
+    content: "・";
+  }
+  50% {
+    content: "・・";
+  }
+  75% {
+    content: "・・・";
+  }
+  100% {
+    content: "";
+  }
+}
+</style>

--- a/web/components/sanpaiGrass.js
+++ b/web/components/sanpaiGrass.js
@@ -1,0 +1,97 @@
+// 参拝の草(GitHub風ヒートマップ)のグリッド計算。
+//
+// sanpaiHistoryGo が返す日別集計([{date:"YYYY-MM-DD", count, points}])を
+// 「日曜始まりの週 × 7日」の列構造に変換する。日付はサーバー側でJSTに
+// 正規化済みの文字列なので、ここではタイムゾーンに依存しないよう
+// UTC固定で日数計算だけを行う。
+//
+// 表示(SanpaiGrass.vue / GrassGrid.vue)から分離した純関数にしてあるのは、
+// 週の折り返し・月ラベル・年分割をNodeで決定論的に検証するため
+// (omikujiFox.js と同じ流儀)。
+
+var DAY_MS = 24 * 60 * 60 * 1000;
+
+function parseDate(s) {
+  return new Date(s + "T00:00:00Z");
+}
+
+function formatDate(d) {
+  return d.toISOString().slice(0, 10);
+}
+
+// count → 草の濃さ(0〜4)。GitHubと同じく上限を設けて頭打ちにする。
+function levelFor(count) {
+  if (count <= 0) return 0;
+  if (count === 1) return 1;
+  if (count === 2) return 2;
+  if (count === 3) return 3;
+  return 4;
+}
+
+// since〜until(両端含む)を日曜始まりの週の列に並べる。
+// days: [{date, count, points}](参拝があった日のみで良い)
+// 返り値: {
+//   weeks: [ [ {date, count, points, inRange} x7 ] ... ]  // 列=週、行=日曜..土曜
+//   monthLabels: [ {week, label} ]  // 「n月」を出す週番号
+// }
+function buildGrassGrid(since, until, days) {
+  var byDate = {};
+  (days || []).forEach(function (d) {
+    byDate[d.date] = d;
+  });
+
+  var start = parseDate(since);
+  var end = parseDate(until);
+  // 先頭列の頭を直前の日曜に揃える(getUTCDay: 0=日曜)。
+  var gridStart = start.getTime() - start.getUTCDay() * DAY_MS;
+
+  var weeks = [];
+  var monthLabels = [];
+  var prevMonth = -1;
+  for (var ws = gridStart; ws <= end.getTime(); ws += 7 * DAY_MS) {
+    var col = [];
+    var firstInRange = null;
+    for (var i = 0; i < 7; i++) {
+      var d = new Date(ws + i * DAY_MS);
+      var dateStr = formatDate(d);
+      var inRange = d.getTime() >= start.getTime() && d.getTime() <= end.getTime();
+      var rec = inRange ? byDate[dateStr] : null;
+      var cell = {
+        date: dateStr,
+        count: rec ? rec.count : 0,
+        points: rec ? rec.points || 0 : 0,
+        inRange: inRange,
+      };
+      if (inRange && !firstInRange) firstInRange = cell;
+      col.push(cell);
+    }
+    // 月ラベル: その週の最初の範囲内の日の月が前の週と変わったら付ける。
+    if (firstInRange) {
+      var month = parseInt(firstInRange.date.slice(5, 7), 10);
+      if (month !== prevMonth) {
+        monthLabels.push({ week: weeks.length, label: month + "月" });
+        prevMonth = month;
+      }
+    }
+    weeks.push(col);
+  }
+  return { weeks: weeks, monthLabels: monthLabels };
+}
+
+// 全期間表示用: 初参拝日〜untilを暦年ごとの範囲に分割する。
+// 各年はグリッドを揃えるため 1/1〜12/31(最終年のみuntilまで)。
+function splitYearRanges(firstDate, until) {
+  var firstYear = parseInt(firstDate.slice(0, 4), 10);
+  var lastYear = parseInt(until.slice(0, 4), 10);
+  var ranges = [];
+  for (var y = firstYear; y <= lastYear; y++) {
+    ranges.push({
+      year: y,
+      since: y + "-01-01",
+      until: y === lastYear ? until : y + "-12-31",
+    });
+  }
+  return ranges;
+}
+
+module.exports = { buildGrassGrid, splitYearRanges, levelFor };

--- a/web/pages/dashboard/index.vue
+++ b/web/pages/dashboard/index.vue
@@ -100,6 +100,12 @@
           <RadarChart :chartData="chartData" />
         </div>
       </div>
+      <!-- 参拝の草 -->
+      <SanpaiGrass
+        v-if="user && user.screen_name"
+        class="mt-4"
+        :screen-name="user.screen_name"
+      />
     </div>
     <Loading v-if="isLoading" message="ヨミコミチュウ..."></Loading>
   </main>

--- a/web/pages/u/_userName.vue
+++ b/web/pages/u/_userName.vue
@@ -89,6 +89,8 @@
           </div>
         </div>
       </div>
+      <!-- 参拝の草(公開データ。ポートフォリオとして参拝の継続を見せる) -->
+      <SanpaiGrass class="mt-4" :screen-name="$route.params.userName" />
     </div>
     <div v-if="!isLogin" class="text-center">
       <nuxt-link


### PR DESCRIPTION
## 概要

ユーザーページを**ポートフォリオとして使える**ようにする第一弾。参拝履歴を GitHub のコントリビューショングラフ風のヒートマップ(草)で表示します。

## 仕組み

参拝成功ごとに既に記録されている `users/{github_id}/sanpai_logs`(`add_point`, `timestamp`)を読み取り専用で集計します。**新規の書き込みは無し**なので、2021/12/31 のリリース以降の過去の参拝がそのまま草になります。

## 変更内容

### バックエンド(`app/functions-go/sanpai_history.go` 新規)
- `GET sanpaiHistoryGo?user={screen_name}` … 直近371日(53週)を範囲クエリで取得
- `GET ...&all=1` … 全期間(最古のログ〜現在)。履歴全量の読み取りが走るためフロントの明示ボタンでのみ呼ぶ
- JST固定で日毎集計(`{date, count, points}`)。集計は純関数でユニットテスト、エミュレータ統合テスト付き
- CDNキャッシュ(rankingと同方針): デフォルト `s-maxage=300`、全期間は過去分がほぼ不変なので `s-maxage=3600`

### 配信・デプロイ
- `app/firebase.json` に `/sanpaiHistoryGo` rewrite(Hosting経由でエッジキャッシュ)
- dev/prod 両ワークフローの並列deployブロックに `sanpaiHistoryGo` を追加

### フロントエンド
- `web/components/sanpaiGrass.js` … 週折り返し・月ラベル・年分割の純関数(Node検証済み)
- `web/components/GrassGrid.vue` … 1期間分のCSSグリッド描画(チャートライブラリ不使用、モバイルは横スクロール・初期位置は直近側)
- `web/components/SanpaiGrass.vue` … 直近1年の草+凡例+**「📜 全期間を解析する」ボタン**。押すと初参拝まで遡り、年ごとの草を縦に並べて表示+サマリー(初参拝日・累計参拝・累計pt)
- 設置場所: 公開プロフィール `/u/{userName}` とマイページ `/dashboard`

## 検証

- `go test ./...` 全パス(Firestoreエミュレータ統合テスト含む: 直近/全期間/JST境界/空/未登録404/キャッシュヘッダ)
- グリッド純関数をNodeで検証(371日=54列・日曜始まり・月ラベル13個・うるう日・年分割2021〜2026)
- `yarn generate` 成功
- ヘッドレスChromiumで描画確認: 密/疎/ゼロの直近1年、全期間解析ボタン→6年分の年別草+サマリー、ツールチップ、右端スクロール初期位置

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_