### PR TITLE
参拝ストリーク・累計・称号バッジを追加(profileStatsGo)

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -267,6 +267,8 @@ jobs:
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           deploy sanpaiHistoryGo SanpaiHistoryGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
+          deploy profileStatsGo ProfileStatsGo \
+            --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           deploy omikujiGo OmikujiGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s \
             --set-env-vars="OMIKUJI_COOLDOWN_SECONDS=60"

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -215,6 +215,8 @@ jobs:
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           deploy sanpaiHistoryGo SanpaiHistoryGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
+          deploy profileStatsGo ProfileStatsGo \
+            --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           deploy omikujiGo OmikujiGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s \
             --set-env-vars="OMIKUJI_COOLDOWN_SECONDS=28800"

--- a/app/firebase.json
+++ b/app/firebase.json
@@ -24,6 +24,10 @@
         "function": "sanpaiHistoryGo"
       },
       {
+        "source": "/profileStatsGo",
+        "function": "profileStatsGo"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/app/functions-go/omikuji.go
+++ b/app/functions-go/omikuji.go
@@ -267,6 +267,16 @@ func runOmikuji(ctx context.Context, w http.ResponseWriter, client *firestore.Cl
 		return err
 	}
 
+	// 統計・称号用の履歴(読み手: profileStatsGo)。sanpai_logs と同じ流儀で
+	// 1回の抽選ごとに1ドキュメント残す。導入以前の抽選は遡れない。
+	if _, _, err := userRef.Collection("omikuji_logs").Add(ctx, map[string]interface{}{
+		"entry_id":  entry.ID,
+		"tier":      entry.Tier,
+		"timestamp": firestore.ServerTimestamp,
+	}); err != nil {
+		return err
+	}
+
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"status":            "success",
 		"remaining_seconds": cooldown,

--- a/app/functions-go/profile_stats.go
+++ b/app/functions-go/profile_stats.go
@@ -1,0 +1,288 @@
+// プロフィール統計(ポートフォリオ用)エンドポイント。
+//
+// 参拝ログ(sanpai_logs)とおみくじログ(omikuji_logs)を集計して、
+// 累計参拝・連続参拝ストリーク・おみくじ統計・称号(バッジ)を返す。
+// 公開プロフィール(/u/{userName})とマイページの ProfileStats.vue が表示する。
+//
+//	GET ?user={screen_name}
+//
+// レベルはユーザードキュメントの status キャッシュ(statusGo が書く)から読む。
+// キャッシュ未計算のユーザーは 0 になるが、statusGo が同じページで呼ばれて
+// キャッシュが埋まるため次回以降は埋まる。
+package gofunctions
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+)
+
+func init() {
+	functions.HTTP("ProfileStatsGo", profileStatsHandler)
+}
+
+type sanpaiStats struct {
+	TotalCount    int    `json:"total_count"`
+	TotalPoints   int64  `json:"total_points"`
+	FirstSanpai   string `json:"first_sanpai,omitempty"`
+	CurrentStreak int    `json:"current_streak"`
+	LongestStreak int    `json:"longest_streak"`
+}
+
+type omikujiStats struct {
+	TotalCount int            `json:"total_count"`
+	Tiers      map[string]int `json:"tiers"`
+}
+
+type profileBadge struct {
+	ID       string `json:"id"`
+	Label    string `json:"label"`
+	Emoji    string `json:"emoji"`
+	Desc     string `json:"desc"`
+	Achieved bool   `json:"achieved"`
+}
+
+type profileStatsResponse struct {
+	Sanpai  sanpaiStats    `json:"sanpai"`
+	Omikuji omikujiStats   `json:"omikuji"`
+	Level   int            `json:"level"`
+	Badges  []profileBadge `json:"badges"`
+}
+
+func profileStatsHandler(w http.ResponseWriter, r *http.Request) {
+	setCORSHeaders(w, r)
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Access-Control-Allow-Methods", "GET,OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type,Authorization")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	screenName := r.URL.Query().Get("user")
+	if screenName == "" {
+		writeError(w, http.StatusBadRequest, "user is required")
+		return
+	}
+
+	ctx := r.Context()
+	client, err := getFirestoreClient(ctx)
+	if err != nil {
+		log.Printf("profileStats: getFirestoreClient error: %v", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	if err := runProfileStats(ctx, w, client, screenName, time.Now()); err != nil {
+		log.Printf("profileStats: %v", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+	}
+}
+
+func runProfileStats(ctx context.Context, w http.ResponseWriter, client *firestore.Client, screenName string, now time.Time) error {
+	userDoc, err := findUserByScreenName(ctx, client, screenName)
+	if err != nil {
+		return err
+	}
+	if userDoc == nil {
+		writeError(w, http.StatusNotFound, "user not registered.")
+		return nil
+	}
+
+	// 参拝: 全ログを日毎に集計してストリークを出す(草の all=1 と同じ読み取り量)。
+	entries, err := loadSanpaiLogs(ctx, userDoc.Ref.Collection("sanpai_logs").Query)
+	if err != nil {
+		return err
+	}
+	days := aggregateSanpaiDays(entries, jstLocation)
+
+	stats := sanpaiStats{}
+	for _, e := range entries {
+		stats.TotalCount++
+		stats.TotalPoints += e.AddPoint
+	}
+	if len(days) > 0 {
+		stats.FirstSanpai = days[0].Date
+	}
+	stats.CurrentStreak, stats.LongestStreak = computeStreaks(days, now)
+
+	// おみくじ: omikuji_logs(#155以降に記録開始)をレア度別に数える。
+	omStats, err := loadOmikujiStats(ctx, userDoc)
+	if err != nil {
+		return err
+	}
+
+	level := readCachedLevel(userDoc)
+
+	resp := profileStatsResponse{
+		Sanpai:  stats,
+		Omikuji: omStats,
+		Level:   level,
+		Badges: computeBadges(profileFacts{
+			SanpaiTotal:   stats.TotalCount,
+			CurrentStreak: stats.CurrentStreak,
+			LongestStreak: stats.LongestStreak,
+			Level:         level,
+			OmikujiTotal:  omStats.TotalCount,
+			ChokichiCount: omStats.Tiers["超吉"],
+			DaikyoCount:   omStats.Tiers["大凶"],
+		}),
+	}
+
+	// 公開データ・userでキー分離。参拝直後にストリークが伸びるのが見えるよう
+	// 草のデフォルトと同じ短めのCDNキャッシュにする。
+	w.Header().Set("Cache-Control", "public, max-age=60, s-maxage=300, stale-while-revalidate=600")
+	writeJSON(w, http.StatusOK, resp)
+	return nil
+}
+
+// computeStreaks は日別集計(昇順)から連続参拝日数を計算する(純関数)。
+//   - current: 今日または昨日から途切れず遡れる日数(今日まだ参拝していなくても
+//     昨日までの連続は「継続中」として数える)
+//   - longest: 期間中の最長連続日数
+func computeStreaks(days []sanpaiHistoryDay, now time.Time) (current, longest int) {
+	if len(days) == 0 {
+		return 0, 0
+	}
+	dates := make(map[string]bool, len(days))
+	for _, d := range days {
+		dates[d.Date] = true
+	}
+
+	// longest: 昇順の日別リストを1日刻みの連続で数える。
+	run := 1
+	longest = 1
+	for i := 1; i < len(days); i++ {
+		if nextDateJST(days[i-1].Date) == days[i].Date {
+			run++
+		} else {
+			run = 1
+		}
+		if run > longest {
+			longest = run
+		}
+	}
+
+	// current: 今日から遡る。今日が未参拝なら昨日を起点にする。
+	today := startOfDayJST(now)
+	cursor := formatDateJST(today)
+	if !dates[cursor] {
+		cursor = formatDateJST(today.AddDate(0, 0, -1))
+	}
+	for dates[cursor] {
+		current++
+		cursor = prevDateJST(cursor)
+	}
+	return current, longest
+}
+
+func nextDateJST(date string) string {
+	t, err := time.ParseInLocation("2006-01-02", date, jstLocation)
+	if err != nil {
+		return ""
+	}
+	return t.AddDate(0, 0, 1).Format("2006-01-02")
+}
+
+func prevDateJST(date string) string {
+	t, err := time.ParseInLocation("2006-01-02", date, jstLocation)
+	if err != nil {
+		return ""
+	}
+	return t.AddDate(0, 0, -1).Format("2006-01-02")
+}
+
+type omikujiLogDoc struct {
+	Tier string `firestore:"tier"`
+}
+
+func loadOmikujiStats(ctx context.Context, userDoc *firestore.DocumentSnapshot) (omikujiStats, error) {
+	stats := omikujiStats{Tiers: map[string]int{}}
+	docs, err := userDoc.Ref.Collection("omikuji_logs").Documents(ctx).GetAll()
+	if err != nil {
+		return stats, err
+	}
+	for _, doc := range docs {
+		var d omikujiLogDoc
+		if err := doc.DataTo(&d); err != nil {
+			return stats, err
+		}
+		if d.Tier == "" {
+			continue
+		}
+		stats.TotalCount++
+		stats.Tiers[d.Tier]++
+	}
+	return stats, nil
+}
+
+// readCachedLevel は statusGo が書く status キャッシュからレベルを取り出す。
+// 未計算・型不一致は 0(バッジ判定でレベル条件が付かないだけで害はない)。
+func readCachedLevel(userDoc *firestore.DocumentSnapshot) int {
+	v, err := userDoc.DataAt("status.level")
+	if err != nil {
+		return 0
+	}
+	if n, ok := v.(int64); ok {
+		return int(n)
+	}
+	return 0
+}
+
+// profileFacts は称号判定に使う事実の集合。
+type profileFacts struct {
+	SanpaiTotal   int
+	CurrentStreak int
+	LongestStreak int
+	Level         int
+	OmikujiTotal  int
+	ChokichiCount int
+	DaikyoCount   int
+}
+
+type badgeDef struct {
+	ID       string
+	Label    string
+	Emoji    string
+	Desc     string
+	Achieved func(profileFacts) bool
+}
+
+// 称号の定義。達成済みかどうかに関わらず全件返し、フロントで未達成をグレー表示
+// する(コレクション欲を煽る)。条件はすべて既存の集計から導出できるものに限る。
+var badgeDefs = []badgeDef{
+	{"hatsumode", "初参拝", "⛩️", "はじめての参拝", func(f profileFacts) bool { return f.SanpaiTotal >= 1 }},
+	{"sanpai10", "常連さん", "🏮", "参拝10回", func(f profileFacts) bool { return f.SanpaiTotal >= 10 }},
+	{"sanpai50", "信徒", "🙏", "参拝50回", func(f profileFacts) bool { return f.SanpaiTotal >= 50 }},
+	{"sanpai100", "百度参り", "💯", "参拝100回", func(f profileFacts) bool { return f.SanpaiTotal >= 100 }},
+	{"sanpai365", "毎日詣で", "📅", "参拝365回", func(f profileFacts) bool { return f.SanpaiTotal >= 365 }},
+	{"sanpai1000", "千日参り", "🌟", "参拝1000回", func(f profileFacts) bool { return f.SanpaiTotal >= 1000 }},
+	{"streak3", "三日坊主克服", "🔥", "3日連続参拝", func(f profileFacts) bool { return f.LongestStreak >= 3 }},
+	{"streak7", "七日詣", "🕯️", "7日連続参拝", func(f profileFacts) bool { return f.LongestStreak >= 7 }},
+	{"streak30", "皆勤賞", "🎖️", "30日連続参拝", func(f profileFacts) bool { return f.LongestStreak >= 30 }},
+	{"streak100", "求道者", "⚡", "100日連続参拝", func(f profileFacts) bool { return f.LongestStreak >= 100 }},
+	{"lv10", "見習い神主", "🌱", "レベル10到達", func(f profileFacts) bool { return f.Level >= 10 }},
+	{"lv25", "本殿の主", "🛠️", "レベル25到達", func(f profileFacts) bool { return f.Level >= 25 }},
+	{"lv50", "生き神", "👑", "レベル50到達", func(f profileFacts) bool { return f.Level >= 50 }},
+	{"omikuji10", "おみくじ好き", "🎋", "おみくじ10回", func(f profileFacts) bool { return f.OmikujiTotal >= 10 }},
+	{"chokichi", "天に選ばれし者", "🌈", "超吉を引いた", func(f profileFacts) bool { return f.ChokichiCount >= 1 }},
+	{"daikyo", "受難の日", "💀", "大凶を引いた", func(f profileFacts) bool { return f.DaikyoCount >= 1 }},
+	{"daikyo3", "不運の帝王", "🌩️", "大凶を3回引いた", func(f profileFacts) bool { return f.DaikyoCount >= 3 }},
+}
+
+func computeBadges(f profileFacts) []profileBadge {
+	badges := make([]profileBadge, 0, len(badgeDefs))
+	for _, def := range badgeDefs {
+		badges = append(badges, profileBadge{
+			ID:       def.ID,
+			Label:    def.Label,
+			Emoji:    def.Emoji,
+			Desc:     def.Desc,
+			Achieved: def.Achieved(f),
+		})
+	}
+	return badges
+}

--- a/app/functions-go/profile_stats_integration_test.go
+++ b/app/functions-go/profile_stats_integration_test.go
@@ -1,0 +1,138 @@
+package gofunctions
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// Firestore エミュレータが必要(FIRESTORE_EMULATOR_HOST 未設定時は自動スキップ)。
+
+func TestProfileStats_Basic(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	uid := "profile-stats-test-user-1"
+	userRef := client.Collection("users").Doc(uid)
+	if _, err := userRef.Set(ctx, map[string]interface{}{
+		"screen_name": "stats-tester",
+		"status":      map[string]interface{}{"level": int64(12)},
+	}); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		for _, sub := range []string{"sanpai_logs", "omikuji_logs"} {
+			iter := userRef.Collection(sub).Documents(context.Background())
+			for {
+				doc, err := iter.Next()
+				if err != nil {
+					break
+				}
+				doc.Ref.Delete(context.Background())
+			}
+		}
+		userRef.Delete(context.Background())
+	})
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, jstLocation)
+	// 3日連続(7/8,7/9,7/10) + 離れた1日(7/1)
+	seedSanpaiLog(t, userRef, time.Date(2026, 7, 8, 9, 0, 0, 0, jstLocation), 5)
+	seedSanpaiLog(t, userRef, time.Date(2026, 7, 9, 9, 0, 0, 0, jstLocation), 5)
+	seedSanpaiLog(t, userRef, time.Date(2026, 7, 10, 9, 0, 0, 0, jstLocation), 5)
+	seedSanpaiLog(t, userRef, time.Date(2026, 7, 1, 9, 0, 0, 0, jstLocation), 5)
+	// おみくじログ: 大凶1回
+	if _, _, err := userRef.Collection("omikuji_logs").Add(ctx, map[string]interface{}{
+		"entry_id": "daikyo-001", "tier": "大凶", "timestamp": now,
+	}); err != nil {
+		t.Fatalf("seed omikuji_log: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	if err := runProfileStats(ctx, rec, client, "stats-tester", now); err != nil {
+		t.Fatalf("runProfileStats: %v", err)
+	}
+	var resp profileStatsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v (body=%s)", err, rec.Body.String())
+	}
+
+	if resp.Sanpai.TotalCount != 4 || resp.Sanpai.TotalPoints != 20 {
+		t.Errorf("sanpai totals = %+v, want count=4 points=20", resp.Sanpai)
+	}
+	if resp.Sanpai.FirstSanpai != "2026-07-01" {
+		t.Errorf("first_sanpai = %q, want 2026-07-01", resp.Sanpai.FirstSanpai)
+	}
+	if resp.Sanpai.CurrentStreak != 3 || resp.Sanpai.LongestStreak != 3 {
+		t.Errorf("streaks = %d/%d, want 3/3", resp.Sanpai.CurrentStreak, resp.Sanpai.LongestStreak)
+	}
+	if resp.Omikuji.TotalCount != 1 || resp.Omikuji.Tiers["大凶"] != 1 {
+		t.Errorf("omikuji = %+v", resp.Omikuji)
+	}
+	if resp.Level != 12 {
+		t.Errorf("level = %d, want 12", resp.Level)
+	}
+	achieved := map[string]bool{}
+	for _, b := range resp.Badges {
+		achieved[b.ID] = b.Achieved
+	}
+	if !achieved["hatsumode"] || !achieved["streak3"] || !achieved["lv10"] || !achieved["daikyo"] {
+		t.Errorf("expected badges not achieved: %+v", achieved)
+	}
+	if achieved["sanpai10"] || achieved["daikyo3"] {
+		t.Errorf("unexpected badges achieved: %+v", achieved)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "public, max-age=60, s-maxage=300, stale-while-revalidate=600" {
+		t.Errorf("Cache-Control = %q", got)
+	}
+
+	// 未登録ユーザーは404
+	rec = httptest.NewRecorder()
+	if err := runProfileStats(ctx, rec, client, "no-such-user-stats", now); err != nil {
+		t.Fatalf("runProfileStats unknown: %v", err)
+	}
+	if rec.Code != 404 {
+		t.Errorf("unknown user status = %d, want 404", rec.Code)
+	}
+}
+
+// おみくじを引くと omikuji_logs が書かれる(profileStatsGoのデータ源になる)ことの確認。
+func TestOmikuji_WritesLog(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+	t.Setenv("OMIKUJI_COOLDOWN_SECONDS", "3600")
+
+	uid := "omikuji-log-test-user-1"
+	userRef := client.Collection("users").Doc(uid)
+	if _, err := userRef.Set(ctx, map[string]interface{}{"screen_name": "log-tester"}); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		iter := userRef.Collection("omikuji_logs").Documents(context.Background())
+		for {
+			doc, err := iter.Next()
+			if err != nil {
+				break
+			}
+			doc.Ref.Delete(context.Background())
+		}
+		userRef.Delete(context.Background())
+	})
+
+	rec := httptest.NewRecorder()
+	if err := runOmikuji(ctx, rec, client, omikujiRequestBody{GithubID: uid}); err != nil {
+		t.Fatalf("runOmikuji: %v", err)
+	}
+	docs, err := userRef.Collection("omikuji_logs").Documents(ctx).GetAll()
+	if err != nil {
+		t.Fatalf("read omikuji_logs: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("omikuji_logs count = %d, want 1", len(docs))
+	}
+	data := docs[0].Data()
+	if data["tier"] == "" || data["entry_id"] == "" || data["timestamp"] == nil {
+		t.Errorf("omikuji_log fields missing: %v", data)
+	}
+}

--- a/app/functions-go/profile_stats_test.go
+++ b/app/functions-go/profile_stats_test.go
@@ -1,0 +1,92 @@
+package gofunctions
+
+import (
+	"testing"
+	"time"
+)
+
+func day(date string, count int) sanpaiHistoryDay {
+	return sanpaiHistoryDay{Date: date, Count: count}
+}
+
+func TestComputeStreaks(t *testing.T) {
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, jstLocation)
+
+	for _, tc := range []struct {
+		name            string
+		days            []sanpaiHistoryDay
+		current, longest int
+	}{
+		{"empty", nil, 0, 0},
+		{"only today", []sanpaiHistoryDay{day("2026-07-10", 1)}, 1, 1},
+		{
+			// 今日まだ参拝していなくても昨日までの連続は継続中として数える
+			"ends yesterday",
+			[]sanpaiHistoryDay{day("2026-07-07", 1), day("2026-07-08", 2), day("2026-07-09", 1)},
+			3, 3,
+		},
+		{
+			// 一昨日で途切れている → current=0
+			"broken",
+			[]sanpaiHistoryDay{day("2026-07-06", 1), day("2026-07-07", 1), day("2026-07-08", 1)},
+			0, 3,
+		},
+		{
+			// 過去の長い連続 vs 現在の短い連続
+			"longest in past",
+			[]sanpaiHistoryDay{
+				day("2026-01-01", 1), day("2026-01-02", 1), day("2026-01-03", 1),
+				day("2026-01-04", 1), day("2026-01-05", 1),
+				day("2026-07-09", 1), day("2026-07-10", 1),
+			},
+			2, 5,
+		},
+		{
+			// 月跨ぎの連続(1/31→2/1)
+			"month boundary",
+			[]sanpaiHistoryDay{day("2026-01-31", 1), day("2026-02-01", 1)},
+			0, 2,
+		},
+	} {
+		cur, lon := computeStreaks(tc.days, now)
+		if cur != tc.current || lon != tc.longest {
+			t.Errorf("%s: streaks = (%d,%d), want (%d,%d)", tc.name, cur, lon, tc.current, tc.longest)
+		}
+	}
+}
+
+func TestComputeBadges(t *testing.T) {
+	// 未達成: 全部 achieved=false で全件返る
+	none := computeBadges(profileFacts{})
+	if len(none) != len(badgeDefs) {
+		t.Fatalf("badges = %d, want %d", len(none), len(badgeDefs))
+	}
+	for _, b := range none {
+		if b.Achieved {
+			t.Errorf("badge %s achieved with zero facts", b.ID)
+		}
+	}
+
+	// 代表的な達成パターン
+	got := map[string]bool{}
+	for _, b := range computeBadges(profileFacts{
+		SanpaiTotal:   120,
+		LongestStreak: 8,
+		Level:         26,
+		OmikujiTotal:  12,
+		DaikyoCount:   3,
+	}) {
+		got[b.ID] = b.Achieved
+	}
+	for id, want := range map[string]bool{
+		"hatsumode": true, "sanpai10": true, "sanpai50": true, "sanpai100": true,
+		"sanpai365": false, "sanpai1000": false,
+		"streak3": true, "streak7": true, "streak30": false,
+		"lv10": true, "lv25": true, "lv50": false,
+		"omikuji10": true, "chokichi": false, "daikyo": true, "daikyo3": true,
+	} {
+		if got[id] != want {
+			t.Errorf("badge %s = %v, want %v", id, got[id], want)
+		}
+	}
+}

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -498,3 +498,21 @@ Node版との差分(意図的な改善):
   チャートライブラリ不使用のCSSグリッド)。
 - `web/components/SanpaiGrass.vue` … 取得と状態管理。直近1年+「全期間を解析する」
   ボタンで年ごとの草を縦に並べる。設置場所は `/u/{userName}`(公開)と `/dashboard`。
+
+## プロフィール統計(ストリーク・称号)エンドポイント profileStatsGo
+
+ポートフォリオ第二弾。`GET profileStatsGo?user={screen_name}` が
+sanpai_logs / omikuji_logs を集計して返す(表示: `web/components/ProfileStats.vue`、
+設置は `/u/{userName}` と `/dashboard`)。
+
+- **参拝統計**: 累計回数・累計ポイント・初参拝日・連続参拝ストリーク(現在/最長)。
+  ストリークは草と同じ日別集計(JST)から `computeStreaks`(純関数)で算出。
+  「今日まだ参拝していない」場合は昨日までの連続を継続中として数える。
+- **おみくじ統計**: 抽選成功時に `users/{id}/omikuji_logs`(`entry_id`, `tier`,
+  `timestamp`)を書くようにした(#156〜)。導入以前の抽選は遡れない。
+- **称号(バッジ)**: 参拝回数・ストリーク・レベル・おみくじ結果から導出する17種
+  (`badgeDefs`)。達成/未達成の全件を返し、フロントで未達成をグレー表示する。
+  レベルは status キャッシュ(`status.level`)から読む。
+- キャッシュ: 草のデフォルトと同じ
+  `public, max-age=60, s-maxage=300, stale-while-revalidate=600`
+  (`/profileStatsGo` の Hosting rewrite 経由)。

--- a/web/components/ProfileStats.vue
+++ b/web/components/ProfileStats.vue
@@ -1,0 +1,220 @@
+<template>
+  <div class="profile-stats p-3 rounded">
+    <div class="d-flex justify-content-between align-items-center flex-wrap mb-2">
+      <div class="stats-title">📊 参拝の記録</div>
+    </div>
+
+    <div v-if="state === 'loading'" class="stats-sub py-3">
+      記録を紐解いています<span class="dots"></span>
+    </div>
+    <div v-else-if="state === 'error'" class="py-2">
+      <span class="stats-sub">記録を読み込めませんでした。</span>
+      <button class="btn btn-sm btn-outline-light ms-2" @click="fetchStats">
+        再読み込み
+      </button>
+    </div>
+    <template v-else>
+      <!-- 数値タイル -->
+      <div class="tiles">
+        <div class="tile">
+          <div class="tile-value">{{ stats.sanpai.total_count.toLocaleString() }}</div>
+          <div class="tile-label">累計参拝</div>
+        </div>
+        <div class="tile">
+          <div class="tile-value">
+            {{ stats.sanpai.current_streak
+            }}<span class="tile-unit">日</span>
+            <span v-if="stats.sanpai.current_streak >= 3">🔥</span>
+          </div>
+          <div class="tile-label">連続参拝中</div>
+        </div>
+        <div class="tile">
+          <div class="tile-value">{{ stats.sanpai.longest_streak }}<span class="tile-unit">日</span></div>
+          <div class="tile-label">最長ストリーク</div>
+        </div>
+        <div class="tile">
+          <div class="tile-value tile-date">{{ stats.sanpai.first_sanpai || "-" }}</div>
+          <div class="tile-label">初参拝</div>
+        </div>
+      </div>
+
+      <!-- 称号(未達成はグレー表示でコレクション欲を煽る) -->
+      <div class="stats-sub mt-3 mb-1">
+        称号 <span class="ms-1">{{ achievedCount }}/{{ stats.badges.length }}</span>
+      </div>
+      <div class="badges">
+        <span
+          v-for="b in stats.badges"
+          :key="b.id"
+          class="badge-chip"
+          :class="{ locked: !b.achieved }"
+          :title="b.desc + (b.achieved ? '' : '(未達成)')"
+        >
+          {{ b.emoji }} {{ b.label }}
+        </span>
+      </div>
+
+      <!-- おみくじ統計(記録があるときだけ) -->
+      <template v-if="stats.omikuji.total_count > 0">
+        <div class="stats-sub mt-3 mb-1">
+          おみくじ {{ stats.omikuji.total_count }}回
+        </div>
+        <div class="badges">
+          <span
+            v-for="tier in tierOrder"
+            v-if="stats.omikuji.tiers[tier]"
+            :key="tier"
+            class="badge-chip tier-chip"
+          >
+            {{ tierEmoji[tier] }} {{ tier }} ×{{ stats.omikuji.tiers[tier] }}
+          </span>
+        </div>
+      </template>
+    </template>
+  </div>
+</template>
+
+<script>
+// ポートフォリオ用の参拝統計(累計・ストリーク・称号・おみくじ統計)。
+// データ源は profileStatsGo(sanpai_logs / omikuji_logs の集計)。
+export default {
+  props: {
+    screenName: { type: String, required: true },
+  },
+  data() {
+    return {
+      state: "loading", // loading | loaded | error
+      stats: null,
+      tierOrder: ["超吉", "大吉", "中吉", "小吉", "末吉", "凶", "大凶"],
+      tierEmoji: {
+        超吉: "🌟",
+        大吉: "🎉",
+        中吉: "😊",
+        小吉: "🙂",
+        末吉: "😌",
+        凶: "😰",
+        大凶: "💀",
+      },
+    };
+  },
+  computed: {
+    achievedCount() {
+      return this.stats.badges.filter((b) => b.achieved).length;
+    },
+  },
+  async mounted() {
+    await this.fetchStats();
+  },
+  methods: {
+    async fetchStats() {
+      this.state = "loading";
+      try {
+        // 草(sanpaiHistoryGo)と同じく Hosting CDN 経由でエッジキャッシュさせる。
+        const res = await this.$axios.get("/profileStatsGo", {
+          baseURL: this.$config.rankingBaseUrl || this.$config.apiUrl,
+          params: { user: this.screenName },
+        });
+        this.stats = res.data;
+        this.state = "loaded";
+      } catch (e) {
+        this.state = "error";
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.profile-stats {
+  background: #0d1117;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+.stats-title {
+  font-weight: 700;
+}
+.stats-sub {
+  color: #9a9a9a;
+  font-size: 0.85rem;
+}
+
+/* 数値タイル */
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 10px;
+}
+.tile {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 10px 12px;
+  text-align: center;
+}
+.tile-value {
+  font-size: 1.5rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+.tile-value.tile-date {
+  font-size: 1.05rem;
+  padding-top: 0.35rem;
+}
+.tile-unit {
+  font-size: 0.9rem;
+  font-weight: 400;
+  margin-left: 1px;
+}
+.tile-label {
+  color: #9a9a9a;
+  font-size: 0.8rem;
+  margin-top: 2px;
+}
+
+/* 称号チップ */
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.badge-chip {
+  background: rgba(255, 196, 120, 0.12);
+  border: 1px solid rgba(255, 196, 120, 0.4);
+  border-radius: 999px;
+  padding: 3px 10px;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+.badge-chip.locked {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.12);
+  color: #777;
+  filter: grayscale(1);
+  opacity: 0.7;
+}
+.badge-chip.tier-chip {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+/* 読み込み中の「...」 */
+.dots::after {
+  content: "";
+  animation: stats-dots 1.2s steps(4, end) infinite;
+}
+@keyframes stats-dots {
+  0% {
+    content: "";
+  }
+  25% {
+    content: "・";
+  }
+  50% {
+    content: "・・";
+  }
+  75% {
+    content: "・・・";
+  }
+  100% {
+    content: "";
+  }
+}
+</style>

--- a/web/pages/dashboard/index.vue
+++ b/web/pages/dashboard/index.vue
@@ -100,7 +100,12 @@
           <RadarChart :chartData="chartData" />
         </div>
       </div>
-      <!-- 参拝の草 -->
+      <!-- 参拝の記録(累計・ストリーク・称号)と草 -->
+      <ProfileStats
+        v-if="user && user.screen_name"
+        class="mt-4"
+        :screen-name="user.screen_name"
+      />
       <SanpaiGrass
         v-if="user && user.screen_name"
         class="mt-4"

--- a/web/pages/u/_userName.vue
+++ b/web/pages/u/_userName.vue
@@ -89,7 +89,8 @@
           </div>
         </div>
       </div>
-      <!-- 参拝の草(公開データ。ポートフォリオとして参拝の継続を見せる) -->
+      <!-- 参拝の記録(累計・ストリーク・称号)と草。ポートフォリオの中核 -->
+      <ProfileStats class="mt-4" :screen-name="$route.params.userName" />
       <SanpaiGrass class="mt-4" :screen-name="$route.params.userName" />
     </div>
     <div v-if="!isLogin" class="text-center">


### PR DESCRIPTION
## 概要

ポートフォリオ第二弾。公開プロフィール(`/u/{userName}`)とマイページに**「📊 参拝の記録」**を追加します。

- 数値タイル: **累計参拝・連続参拝中(🔥)・最長ストリーク・初参拝日**
- **称号バッジ17種**(初参拝/百度参り/千日参り/三日坊主克服/皆勤賞/生き神/超吉を引いた/不運の帝王 など)。未達成はグレー表示でコレクション欲を煽る
- おみくじ統計(引いた回数・レア度分布)

## 変更内容

### バックエンド(`app/functions-go/profile_stats.go` 新規)
- `GET profileStatsGo?user={screen_name}` — sanpai_logs / omikuji_logs を集計
- ストリークは草と同じJST日別集計から `computeStreaks`(純関数)で算出。今日未参拝でも昨日までの連続は「継続中」として数える
- 称号は `badgeDefs` から導出し達成/未達成の全件を返す。レベルは status キャッシュから
- **おみくじ抽選成功時に `omikuji_logs`(entry_id/tier/timestamp)を記録開始**(統計・称号のデータ源。導入以降から蓄積)
- CDNキャッシュ: `public, max-age=60, s-maxage=300, stale-while-revalidate=600`

### 配信・デプロイ
- `/profileStatsGo` の Hosting rewrite、dev/prod ワークフローにデプロイ追加

### フロントエンド
- `web/components/ProfileStats.vue` 新規。`/u/{userName}` と `/dashboard` の草の上に設置

## 検証

- `go test ./...` 全パス(エミュレータ統合: ストリーク/称号/おみくじログ書き込み/404/キャッシュヘッダ)
- computeStreaks ユニットテスト(空/今日のみ/昨日まで継続/途切れ/過去最長/月跨ぎ)
- `yarn generate` 成功、ヘッドレスで描画確認(実績あり/ゼロの2パターン)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_