### PR TITLE
GitHub実績統計を追加(githubStatsGo)

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -269,6 +269,10 @@ jobs:
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           deploy profileStatsGo ProfileStatsGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
+          # GitHub APIのレート制限緩和のため sanpaiGo と同じOAuth資格情報を使う
+          deploy githubStatsGo GithubStatsGo \
+            --trigger-http --allow-unauthenticated --memory=256Mi --timeout=60s \
+            --set-env-vars="GITHUB_CLIENT_ID=$SANPAI_GH_CLIENT_ID,GITHUB_CLIENT_SECRET=$SANPAI_GH_CLIENT_SECRET"
           deploy omikujiGo OmikujiGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s \
             --set-env-vars="OMIKUJI_COOLDOWN_SECONDS=60"

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -217,6 +217,10 @@ jobs:
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           deploy profileStatsGo ProfileStatsGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
+          # GitHub APIのレート制限緩和のため sanpaiGo と同じOAuth資格情報を使う
+          deploy githubStatsGo GithubStatsGo \
+            --trigger-http --allow-unauthenticated --memory=256Mi --timeout=60s \
+            --set-env-vars="GITHUB_CLIENT_ID=$SANPAI_GH_CLIENT_ID,GITHUB_CLIENT_SECRET=$SANPAI_GH_CLIENT_SECRET"
           deploy omikujiGo OmikujiGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s \
             --set-env-vars="OMIKUJI_COOLDOWN_SECONDS=28800"

--- a/app/firebase.json
+++ b/app/firebase.json
@@ -28,6 +28,10 @@
         "function": "profileStatsGo"
       },
       {
+        "source": "/githubStatsGo",
+        "function": "githubStatsGo"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/app/functions-go/github_stats.go
+++ b/app/functions-go/github_stats.go
@@ -1,0 +1,300 @@
+// GitHub実績統計(ポートフォリオ用)エンドポイント。
+//
+// GitHub公開APIからユーザーの公開リポジトリ・スター・フォロワー等を取得し、
+// ポートフォリオ表示用に集計して返す(表示: web/components/GithubStats.vue)。
+//
+//	GET ?user={screen_name}
+//
+// GitHub APIのレート制限(OAuth App認証で5000req/h)を守るため、集計結果は
+// ユーザードキュメントに6時間キャッシュする。GitHub側の障害時はキャッシュが
+// 古くてもそれを返す(ポートフォリオ表示は鮮度より可用性を優先)。
+package gofunctions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+)
+
+func init() {
+	functions.HTTP("GithubStatsGo", githubStatsHandler)
+}
+
+// githubStatsTTL はFirestoreキャッシュの有効期間。リポジトリ統計は分単位で
+// 変わるものではないため長めに取り、GitHub APIへの到達を抑える。
+const githubStatsTTL = 6 * time.Hour
+
+// githubRepoAPI は GET /users/{login}/repos の1件から使うフィールド。
+type githubRepoAPI struct {
+	Name        string `json:"name"`
+	HTMLURL     string `json:"html_url"`
+	Description string `json:"description"`
+	Stars       int64  `json:"stargazers_count"`
+	Forks       int64  `json:"forks_count"`
+	Language    string `json:"language"`
+	Fork        bool   `json:"fork"`
+}
+
+// githubUserAPI は GET /users/{login} から使うフィールド。
+type githubUserAPI struct {
+	Followers   int64  `json:"followers"`
+	PublicRepos int64  `json:"public_repos"`
+	CreatedAt   string `json:"created_at"`
+}
+
+type githubLangCount struct {
+	Name  string `json:"name" firestore:"name"`
+	Count int64  `json:"count" firestore:"count"`
+}
+
+type githubTopRepo struct {
+	Name        string `json:"name" firestore:"name"`
+	HTMLURL     string `json:"html_url" firestore:"html_url"`
+	Description string `json:"description" firestore:"description"`
+	Stars       int64  `json:"stars" firestore:"stars"`
+	Forks       int64  `json:"forks" firestore:"forks"`
+	Language    string `json:"language" firestore:"language"`
+}
+
+// githubStatsData はFirestoreキャッシュとレスポンス双方の形。
+type githubStatsData struct {
+	Followers        int64             `json:"followers" firestore:"followers"`
+	PublicRepos      int64             `json:"public_repos" firestore:"public_repos"`
+	AccountCreatedAt string            `json:"account_created_at" firestore:"account_created_at"`
+	OriginalCount    int64             `json:"original_count" firestore:"original_count"`
+	ForkCount        int64             `json:"fork_count" firestore:"fork_count"`
+	StarsTotal       int64             `json:"stars_total" firestore:"stars_total"`
+	ForksTotal       int64             `json:"forks_total" firestore:"forks_total"`
+	Languages        []githubLangCount `json:"languages" firestore:"languages"`
+	TopRepos         []githubTopRepo   `json:"top_repos" firestore:"top_repos"`
+}
+
+type githubStatsResponse struct {
+	githubStatsData
+	FetchedAt string `json:"fetched_at"`
+}
+
+func githubStatsHandler(w http.ResponseWriter, r *http.Request) {
+	setCORSHeaders(w, r)
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Access-Control-Allow-Methods", "GET,OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type,Authorization")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	screenName := r.URL.Query().Get("user")
+	if screenName == "" {
+		writeError(w, http.StatusBadRequest, "user is required")
+		return
+	}
+
+	ctx := r.Context()
+	client, err := getFirestoreClient(ctx)
+	if err != nil {
+		log.Printf("githubStats: getFirestoreClient error: %v", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	if err := runGithubStats(ctx, w, client, screenName, time.Now()); err != nil {
+		log.Printf("githubStats: %v", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+	}
+}
+
+func runGithubStats(ctx context.Context, w http.ResponseWriter, client *firestore.Client, screenName string, now time.Time) error {
+	userDoc, err := findUserByScreenName(ctx, client, screenName)
+	if err != nil {
+		return err
+	}
+	if userDoc == nil {
+		writeError(w, http.StatusNotFound, "user not registered.")
+		return nil
+	}
+
+	cached, fetchedAt := readGithubStatsCache(userDoc)
+	if cached != nil && now.Sub(fetchedAt) < githubStatsTTL {
+		writeGithubStatsResponse(w, *cached, fetchedAt)
+		return nil
+	}
+
+	stats, err := fetchGithubStats(ctx, screenName)
+	if err != nil {
+		// GitHub側の失敗。古いキャッシュがあればそれで凌ぐ(可用性優先)。
+		if cached != nil {
+			log.Printf("githubStats: fetch failed, serving stale cache: %v", err)
+			writeGithubStatsResponse(w, *cached, fetchedAt)
+			return nil
+		}
+		log.Printf("githubStats: fetch failed with no cache: %v", err)
+		writeError(w, http.StatusBadGateway, "failed to fetch github stats")
+		return nil
+	}
+
+	if _, err := userDoc.Ref.Update(ctx, []firestore.Update{
+		{Path: "github_stats", Value: stats},
+		{Path: "github_stats_fetched_at", Value: now},
+	}); err != nil {
+		return err
+	}
+
+	writeGithubStatsResponse(w, stats, now)
+	return nil
+}
+
+func writeGithubStatsResponse(w http.ResponseWriter, stats githubStatsData, fetchedAt time.Time) {
+	// 公開データ・userでキー分離。Firestore側で6hキャッシュするためCDNも長めで良い。
+	w.Header().Set("Cache-Control", "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400")
+	writeJSON(w, http.StatusOK, githubStatsResponse{
+		githubStatsData: stats,
+		FetchedAt:       fetchedAt.UTC().Format(time.RFC3339),
+	})
+}
+
+func readGithubStatsCache(userDoc *firestore.DocumentSnapshot) (*githubStatsData, time.Time) {
+	v, err := userDoc.DataAt("github_stats_fetched_at")
+	if err != nil {
+		return nil, time.Time{}
+	}
+	fetchedAt, ok := v.(time.Time)
+	if !ok {
+		return nil, time.Time{}
+	}
+	raw, err := userDoc.DataAt("github_stats")
+	if err != nil || raw == nil {
+		return nil, time.Time{}
+	}
+	// Firestoreのmapを構造体へ移し替える(JSON経由が最も単純で安全)。
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil, time.Time{}
+	}
+	var stats githubStatsData
+	if err := json.Unmarshal(b, &stats); err != nil {
+		return nil, time.Time{}
+	}
+	return &stats, fetchedAt
+}
+
+// fetchGithubStats はGitHub公開APIからユーザー情報と全ownerリポジトリを取得して集計する。
+func fetchGithubStats(ctx context.Context, login string) (githubStatsData, error) {
+	var user githubUserAPI
+	if err := githubGetJSON(ctx, fmt.Sprintf("%s/users/%s", githubAPIBaseURL, url.PathEscape(login)), &user); err != nil {
+		return githubStatsData{}, err
+	}
+
+	// ownerリポジトリを最大3ページ(300件)まで取得。それ以上持つユーザーは稀で、
+	// スター上位・言語割合の傾向は300件で十分に出る。
+	var repos []githubRepoAPI
+	for page := 1; page <= 3; page++ {
+		var batch []githubRepoAPI
+		reqURL := fmt.Sprintf(
+			"%s/users/%s/repos?per_page=100&type=owner&sort=pushed&page=%d",
+			githubAPIBaseURL, url.PathEscape(login), page,
+		)
+		if err := githubGetJSON(ctx, reqURL, &batch); err != nil {
+			return githubStatsData{}, err
+		}
+		repos = append(repos, batch...)
+		if len(batch) < 100 {
+			break
+		}
+	}
+
+	stats := aggregateGithubRepos(repos)
+	stats.Followers = user.Followers
+	stats.PublicRepos = user.PublicRepos
+	stats.AccountCreatedAt = user.CreatedAt
+	return stats, nil
+}
+
+// aggregateGithubRepos はリポジトリ一覧から統計を集計する(純関数)。
+//   - スター/フォーク合計・言語割合は本人作(非フォーク)のみを数える
+//     (フォークのスターや言語は本人の実績ではないため)
+//   - top_repos はスター数上位4件(同数はそのままの順=pushed順)
+func aggregateGithubRepos(repos []githubRepoAPI) githubStatsData {
+	stats := githubStatsData{
+		Languages: []githubLangCount{},
+		TopRepos:  []githubTopRepo{},
+	}
+	langs := map[string]int64{}
+	var originals []githubRepoAPI
+	for _, r := range repos {
+		if r.Fork {
+			stats.ForkCount++
+			continue
+		}
+		stats.OriginalCount++
+		stats.StarsTotal += r.Stars
+		stats.ForksTotal += r.Forks
+		if r.Language != "" {
+			langs[r.Language]++
+		}
+		originals = append(originals, r)
+	}
+
+	for name, count := range langs {
+		stats.Languages = append(stats.Languages, githubLangCount{Name: name, Count: count})
+	}
+	sort.Slice(stats.Languages, func(i, j int) bool {
+		if stats.Languages[i].Count != stats.Languages[j].Count {
+			return stats.Languages[i].Count > stats.Languages[j].Count
+		}
+		return stats.Languages[i].Name < stats.Languages[j].Name
+	})
+
+	sort.SliceStable(originals, func(i, j int) bool { return originals[i].Stars > originals[j].Stars })
+	for i, r := range originals {
+		if i >= 4 {
+			break
+		}
+		stats.TopRepos = append(stats.TopRepos, githubTopRepo{
+			Name:        r.Name,
+			HTMLURL:     r.HTMLURL,
+			Description: r.Description,
+			Stars:       r.Stars,
+			Forks:       r.Forks,
+			Language:    r.Language,
+		})
+	}
+	return stats
+}
+
+// githubGetJSON はGitHub APIへの認証付きGET(sanpai.go fetchGitHubFeed と同じ流儀)。
+func githubGetJSON(ctx context.Context, reqURL string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "debug-shrine-githubStatsGo")
+	clientID := os.Getenv("GITHUB_CLIENT_ID")
+	clientSecret := os.Getenv("GITHUB_CLIENT_SECRET")
+	if clientID != "" && clientSecret != "" {
+		req.SetBasicAuth(clientID, clientSecret)
+	}
+
+	resp, err := githubHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("github api %s: status %d: %s", reqURL, resp.StatusCode, string(body))
+	}
+	return json.Unmarshal(body, out)
+}

--- a/app/functions-go/github_stats_test.go
+++ b/app/functions-go/github_stats_test.go
@@ -1,0 +1,185 @@
+package gofunctions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestAggregateGithubRepos(t *testing.T) {
+	repos := []githubRepoAPI{
+		{Name: "big", Stars: 100, Forks: 10, Language: "Go"},
+		{Name: "mid", Stars: 30, Forks: 3, Language: "Go"},
+		{Name: "small", Stars: 5, Forks: 0, Language: "JavaScript"},
+		{Name: "nolang", Stars: 1, Forks: 0, Language: ""},
+		{Name: "tiny1", Stars: 0, Forks: 0, Language: "Python"},
+		{Name: "tiny2", Stars: 0, Forks: 0, Language: "Python"},
+		// フォークはスター・言語・top_reposに入れない
+		{Name: "forked", Stars: 9999, Forks: 500, Language: "Rust", Fork: true},
+	}
+	stats := aggregateGithubRepos(repos)
+
+	if stats.OriginalCount != 6 || stats.ForkCount != 1 {
+		t.Errorf("counts = %d/%d, want 6/1", stats.OriginalCount, stats.ForkCount)
+	}
+	if stats.StarsTotal != 136 || stats.ForksTotal != 13 {
+		t.Errorf("stars/forks = %d/%d, want 136/13", stats.StarsTotal, stats.ForksTotal)
+	}
+	// 言語はリポジトリ数の降順(同数は名前順)。言語なしは数えない
+	wantLangs := []githubLangCount{{"Go", 2}, {"Python", 2}, {"JavaScript", 1}}
+	if len(stats.Languages) != len(wantLangs) {
+		t.Fatalf("languages = %+v", stats.Languages)
+	}
+	for i, w := range wantLangs {
+		if stats.Languages[i] != w {
+			t.Errorf("languages[%d] = %+v, want %+v", i, stats.Languages[i], w)
+		}
+	}
+	// top_repos はスター上位4件(フォーク除外)
+	if len(stats.TopRepos) != 4 || stats.TopRepos[0].Name != "big" || stats.TopRepos[3].Name != "nolang" {
+		t.Errorf("top_repos = %+v", stats.TopRepos)
+	}
+}
+
+func TestAggregateGithubRepos_Empty(t *testing.T) {
+	stats := aggregateGithubRepos(nil)
+	if stats.OriginalCount != 0 || len(stats.Languages) != 0 || len(stats.TopRepos) != 0 {
+		t.Errorf("empty stats = %+v", stats)
+	}
+	// JSONで null にならない(フロントの .map が壊れない)
+	b, _ := json.Marshal(stats)
+	var m map[string]interface{}
+	json.Unmarshal(b, &m)
+	if m["languages"] == nil || m["top_repos"] == nil {
+		t.Errorf("languages/top_repos should be [] not null: %s", string(b))
+	}
+}
+
+// GitHub APIをモックして fetchGithubStats の取得・ページングを検証する。
+func TestFetchGithubStats_MockServer(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/tester", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"followers": 42, "public_repos": 150, "created_at": "2015-04-01T00:00:00Z"}`)
+	})
+	mux.HandleFunc("/users/tester/repos", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		if r.URL.Query().Get("per_page") != "100" || r.URL.Query().Get("type") != "owner" {
+			t.Errorf("unexpected query: %s", r.URL.RawQuery)
+		}
+		switch page {
+		case "1":
+			// 100件返して次ページを引かせる
+			repos := make([]map[string]interface{}, 100)
+			for i := range repos {
+				repos[i] = map[string]interface{}{
+					"name": fmt.Sprintf("repo%d", i), "stargazers_count": 1, "language": "Go",
+				}
+			}
+			json.NewEncoder(w).Encode(repos)
+		case "2":
+			fmt.Fprint(w, `[{"name":"last","stargazers_count":50,"language":"TypeScript"}]`)
+		default:
+			t.Errorf("unexpected page: %s", page)
+			fmt.Fprint(w, `[]`)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	stats, err := fetchGithubStats(context.Background(), "tester")
+	if err != nil {
+		t.Fatalf("fetchGithubStats: %v", err)
+	}
+	if stats.Followers != 42 || stats.PublicRepos != 150 {
+		t.Errorf("user fields = %+v", stats)
+	}
+	if stats.OriginalCount != 101 || stats.StarsTotal != 150 {
+		t.Errorf("aggregates = original=%d stars=%d, want 101/150", stats.OriginalCount, stats.StarsTotal)
+	}
+	if stats.Languages[0].Name != "Go" || stats.Languages[0].Count != 100 {
+		t.Errorf("languages = %+v", stats.Languages)
+	}
+	if stats.TopRepos[0].Name != "last" || stats.TopRepos[0].Stars != 50 {
+		t.Errorf("top repo = %+v", stats.TopRepos[0])
+	}
+	if stats.AccountCreatedAt != "2015-04-01T00:00:00Z" {
+		t.Errorf("created_at = %q", stats.AccountCreatedAt)
+	}
+}
+
+// エミュレータ統合: キャッシュの書き込みと再利用、GitHub障害時のstale応答。
+func TestGithubStats_CacheAndStale(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	// モックGitHub(1回目だけ成功、以降500)
+	calls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/cache-tester", func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls > 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprint(w, `{"followers": 7, "public_repos": 2, "created_at": "2020-01-01T00:00:00Z"}`)
+	})
+	mux.HandleFunc("/users/cache-tester/repos", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `[{"name":"a","stargazers_count":3,"language":"Go"}]`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	uid := "github-stats-test-user-1"
+	userRef := client.Collection("users").Doc(uid)
+	if _, err := userRef.Set(ctx, map[string]interface{}{"screen_name": "cache-tester"}); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() { userRef.Delete(context.Background()) })
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	// 1回目: GitHubから取得してキャッシュされる
+	rec := httptest.NewRecorder()
+	if err := runGithubStats(ctx, rec, client, "cache-tester", now); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	var resp githubStatsResponse
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Followers != 7 || resp.StarsTotal != 3 {
+		t.Errorf("first resp = %+v", resp)
+	}
+
+	// 2回目(TTL内): GitHubを叩かずキャッシュから返る(callsが増えない)
+	callsBefore := calls
+	rec = httptest.NewRecorder()
+	if err := runGithubStats(ctx, rec, client, "cache-tester", now.Add(time.Hour)); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if calls != callsBefore {
+		t.Errorf("cache hit should not call GitHub (calls %d -> %d)", callsBefore, calls)
+	}
+
+	// 3回目(TTL切れ・GitHubは500): staleキャッシュで応答する
+	rec = httptest.NewRecorder()
+	if err := runGithubStats(ctx, rec, client, "cache-tester", now.Add(7*time.Hour)); err != nil {
+		t.Fatalf("third run: %v", err)
+	}
+	if rec.Code != 200 {
+		t.Fatalf("stale response code = %d, want 200", rec.Code)
+	}
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Followers != 7 {
+		t.Errorf("stale resp = %+v", resp)
+	}
+}

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -516,3 +516,22 @@ sanpai_logs / omikuji_logs を集計して返す(表示: `web/components/Profile
 - キャッシュ: 草のデフォルトと同じ
   `public, max-age=60, s-maxage=300, stale-while-revalidate=600`
   (`/profileStatsGo` の Hosting rewrite 経由)。
+
+## GitHub実績統計エンドポイント githubStatsGo
+
+ポートフォリオ第三弾。`GET githubStatsGo?user={screen_name}` がGitHub公開APIから
+公開リポジトリ・スター・フォロワー等を取得・集計して返す
+(表示: `web/components/GithubStats.vue`)。
+
+- 取得: `GET /users/{login}`(followers/public_repos/created_at)+
+  `GET /users/{login}/repos?per_page=100&type=owner`(最大3ページ=300件)。
+  認証は sanpaiGo と同じOAuth App資格情報のBasic認証(5000req/h)。
+- 集計(`aggregateGithubRepos`、純関数): スター/フォーク合計・言語割合
+  (主要言語のリポジトリ数)・スター上位4件の代表リポジトリ。
+  **フォークはリポジトリ数内訳のみに数え、スター・言語・代表からは除外**
+  (本人の実績ではないため)。
+- キャッシュ2段構え:
+  - Firestore: ユーザードキュメントの `github_stats` + `github_stats_fetched_at` に
+    **6時間**キャッシュ。GitHub障害時は期限切れでもstaleを返す(可用性優先)。
+  - CDN: `public, max-age=300, s-maxage=3600, stale-while-revalidate=86400`
+    (`/githubStatsGo` の Hosting rewrite 経由)。

--- a/web/components/GithubStats.vue
+++ b/web/components/GithubStats.vue
@@ -1,0 +1,338 @@
+<template>
+  <div class="github-stats p-3 rounded">
+    <div class="d-flex justify-content-between align-items-center flex-wrap mb-2">
+      <div class="gh-title"><i class="fab fa-github fa-fw"></i> GitHubの実績</div>
+      <div v-if="state === 'loaded'" class="gh-sub">
+        {{ fetchedAtText }}
+      </div>
+    </div>
+
+    <div v-if="state === 'loading'" class="gh-sub py-3">
+      GitHubの実績を集めています<span class="dots"></span>
+    </div>
+    <div v-else-if="state === 'error'" class="py-2">
+      <span class="gh-sub">GitHubの実績を読み込めませんでした。</span>
+      <button class="btn btn-sm btn-outline-light ms-2" @click="fetchStats">
+        再読み込み
+      </button>
+    </div>
+    <template v-else>
+      <!-- 数値タイル -->
+      <div class="tiles">
+        <div class="tile">
+          <div class="tile-value">{{ stats.public_repos.toLocaleString() }}</div>
+          <div class="tile-label">
+            公開リポジトリ
+            <span v-if="stats.fork_count > 0" class="tile-note">
+              (オリジナル{{ stats.original_count }})
+            </span>
+          </div>
+        </div>
+        <div class="tile">
+          <div class="tile-value">⭐ {{ stats.stars_total.toLocaleString() }}</div>
+          <div class="tile-label">獲得スター</div>
+        </div>
+        <div class="tile">
+          <div class="tile-value">{{ stats.followers.toLocaleString() }}</div>
+          <div class="tile-label">フォロワー</div>
+        </div>
+        <div class="tile">
+          <div class="tile-value">{{ githubYears }}<span class="tile-unit">年</span></div>
+          <div class="tile-label">GitHub歴</div>
+        </div>
+      </div>
+
+      <!-- 言語割合(本人作リポジトリの主要言語) -->
+      <template v-if="languageShares.length > 0">
+        <div class="gh-sub mt-3 mb-1">使用言語(リポジトリ数の割合)</div>
+        <div class="lang-bar" role="img" aria-label="使用言語の割合">
+          <span
+            v-for="l in languageShares"
+            :key="l.name"
+            class="lang-seg"
+            :style="{ width: l.percent + '%', background: l.color }"
+            :title="`${l.name} ${l.percent}% (${l.count}リポジトリ)`"
+          ></span>
+        </div>
+        <div class="lang-legend mt-1">
+          <span v-for="l in languageShares" :key="l.name" class="lang-item">
+            <span class="lang-dot" :style="{ background: l.color }"></span>
+            {{ l.name }} <span class="gh-sub">{{ l.percent }}%</span>
+          </span>
+        </div>
+      </template>
+
+      <!-- 代表リポジトリ(スター上位) -->
+      <template v-if="stats.top_repos.length > 0">
+        <div class="gh-sub mt-3 mb-1">代表リポジトリ</div>
+        <div class="repo-grid">
+          <a
+            v-for="r in stats.top_repos"
+            :key="r.name"
+            :href="r.html_url"
+            target="_blank"
+            rel="noopener"
+            class="repo-card rounded"
+          >
+            <div class="repo-name">
+              <i class="fas fa-book fa-fw"></i> {{ r.name }}
+            </div>
+            <div class="repo-desc">{{ r.description || "説明なし" }}</div>
+            <div class="repo-meta">
+              <span v-if="r.language" class="me-3">
+                <span class="lang-dot" :style="{ background: langColor(r.language) }"></span>
+                {{ r.language }}
+              </span>
+              <span class="me-3">⭐ {{ r.stars.toLocaleString() }}</span>
+              <span v-if="r.forks > 0">🍴 {{ r.forks.toLocaleString() }}</span>
+            </div>
+          </a>
+        </div>
+      </template>
+    </template>
+  </div>
+</template>
+
+<script>
+// GitHubの公開実績(リポジトリ数・スター・言語割合・代表リポジトリ)。
+// データ源は githubStatsGo(GitHub公開APIをFirestoreに6時間キャッシュ)。
+
+// GitHub の言語カラー(主要どころのみ。無い言語はグレー)
+const LANG_COLORS = {
+  JavaScript: "#f1e05a",
+  TypeScript: "#3178c6",
+  Python: "#3572A5",
+  Go: "#00ADD8",
+  Ruby: "#701516",
+  Java: "#b07219",
+  Kotlin: "#A97BFF",
+  Swift: "#F05138",
+  C: "#555555",
+  "C++": "#f34b7d",
+  "C#": "#178600",
+  PHP: "#4F5D95",
+  Rust: "#dea584",
+  Dart: "#00B4AB",
+  HTML: "#e34c26",
+  CSS: "#563d7c",
+  SCSS: "#c6538c",
+  Vue: "#41b883",
+  Svelte: "#ff3e00",
+  Shell: "#89e051",
+  PowerShell: "#012456",
+  Perl: "#0298c3",
+  Haskell: "#5e5086",
+  Elixir: "#6e4a7e",
+  Scala: "#c22d40",
+  Lua: "#000080",
+  R: "#198CE7",
+  "Objective-C": "#438eff",
+  "Jupyter Notebook": "#DA5B0B",
+  Dockerfile: "#384d54",
+};
+const OTHER_COLOR = "#8b949e";
+
+export default {
+  props: {
+    screenName: { type: String, required: true },
+  },
+  data() {
+    return {
+      state: "loading", // loading | loaded | error
+      stats: null,
+    };
+  },
+  computed: {
+    githubYears() {
+      if (!this.stats.account_created_at) return "-";
+      const ms = Date.now() - new Date(this.stats.account_created_at).getTime();
+      return Math.max(0, Math.floor(ms / (365.25 * 24 * 3600 * 1000)));
+    },
+    // 上位6言語+その他に丸めてパーセント化
+    languageShares() {
+      const langs = this.stats.languages || [];
+      const total = langs.reduce((s, l) => s + l.count, 0);
+      if (total === 0) return [];
+      const top = langs.slice(0, 6);
+      const otherCount = langs.slice(6).reduce((s, l) => s + l.count, 0);
+      const shares = top.map((l) => ({
+        name: l.name,
+        count: l.count,
+        percent: Math.round((l.count / total) * 100),
+        color: this.langColor(l.name),
+      }));
+      if (otherCount > 0) {
+        shares.push({
+          name: "その他",
+          count: otherCount,
+          percent: Math.round((otherCount / total) * 100),
+          color: OTHER_COLOR,
+        });
+      }
+      return shares;
+    },
+    fetchedAtText() {
+      if (!this.stats.fetched_at) return "";
+      const d = new Date(this.stats.fetched_at);
+      return `${d.getMonth() + 1}/${d.getDate()} ${d.getHours()}:${String(
+        d.getMinutes()
+      ).padStart(2, "0")} 時点`;
+    },
+  },
+  async mounted() {
+    await this.fetchStats();
+  },
+  methods: {
+    langColor(name) {
+      return LANG_COLORS[name] || OTHER_COLOR;
+    },
+    async fetchStats() {
+      this.state = "loading";
+      try {
+        const res = await this.$axios.get("/githubStatsGo", {
+          baseURL: this.$config.rankingBaseUrl || this.$config.apiUrl,
+          params: { user: this.screenName },
+        });
+        this.stats = res.data;
+        this.state = "loaded";
+      } catch (e) {
+        this.state = "error";
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.github-stats {
+  background: #0d1117;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+.gh-title {
+  font-weight: 700;
+}
+.gh-sub {
+  color: #9a9a9a;
+  font-size: 0.85rem;
+}
+
+/* 数値タイル(ProfileStatsと同じ見た目) */
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 10px;
+}
+.tile {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 10px 12px;
+  text-align: center;
+}
+.tile-value {
+  font-size: 1.5rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+.tile-unit {
+  font-size: 0.9rem;
+  font-weight: 400;
+  margin-left: 1px;
+}
+.tile-label {
+  color: #9a9a9a;
+  font-size: 0.8rem;
+  margin-top: 2px;
+}
+.tile-note {
+  font-size: 0.75rem;
+}
+
+/* 言語割合バー */
+.lang-bar {
+  display: flex;
+  height: 10px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.06);
+}
+.lang-seg {
+  height: 100%;
+  min-width: 2px;
+}
+.lang-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 14px;
+  font-size: 0.85rem;
+}
+.lang-item {
+  white-space: nowrap;
+}
+.lang-dot {
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  margin-right: 4px;
+  vertical-align: baseline;
+}
+
+/* 代表リポジトリ */
+.repo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 10px;
+}
+.repo-card {
+  display: block;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 10px 12px;
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.15s;
+}
+.repo-card:hover {
+  border-color: rgba(255, 196, 120, 0.6);
+  color: inherit;
+}
+.repo-name {
+  font-weight: 700;
+}
+.repo-desc {
+  color: #9a9a9a;
+  font-size: 0.85rem;
+  margin: 4px 0 6px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.repo-meta {
+  font-size: 0.85rem;
+  color: #c9c9c9;
+}
+
+/* 読み込み中の「...」 */
+.dots::after {
+  content: "";
+  animation: gh-dots 1.2s steps(4, end) infinite;
+}
+@keyframes gh-dots {
+  0% {
+    content: "";
+  }
+  25% {
+    content: "・";
+  }
+  50% {
+    content: "・・";
+  }
+  75% {
+    content: "・・・";
+  }
+  100% {
+    content: "";
+  }
+}
+</style>

--- a/web/pages/dashboard/index.vue
+++ b/web/pages/dashboard/index.vue
@@ -100,8 +100,13 @@
           <RadarChart :chartData="chartData" />
         </div>
       </div>
-      <!-- 参拝の記録(累計・ストリーク・称号)と草 -->
+      <!-- ポートフォリオ: 参拝の記録(累計・ストリーク・称号)/GitHub実績/草 -->
       <ProfileStats
+        v-if="user && user.screen_name"
+        class="mt-4"
+        :screen-name="user.screen_name"
+      />
+      <GithubStats
         v-if="user && user.screen_name"
         class="mt-4"
         :screen-name="user.screen_name"

--- a/web/pages/u/_userName.vue
+++ b/web/pages/u/_userName.vue
@@ -89,8 +89,9 @@
           </div>
         </div>
       </div>
-      <!-- 参拝の記録(累計・ストリーク・称号)と草。ポートフォリオの中核 -->
+      <!-- ポートフォリオ: 参拝の記録(累計・ストリーク・称号)/GitHub実績/草 -->
       <ProfileStats class="mt-4" :screen-name="$route.params.userName" />
+      <GithubStats class="mt-4" :screen-name="$route.params.userName" />
       <SanpaiGrass class="mt-4" :screen-name="$route.params.userName" />
     </div>
     <div v-if="!isLogin" class="text-center">


### PR DESCRIPTION
## 概要

ポートフォリオ第三弾。公開プロフィール(`/u/{userName}`)とマイページに**「GitHubの実績」**を追加します。

- 数値タイル: **公開リポジトリ(オリジナル内訳)・獲得スター⭐・フォロワー・GitHub歴**
- **使用言語の割合バー**(GitHub言語色、上位6言語+その他)
- **代表リポジトリ**(スター上位4件のカード: 説明・⭐・🍴・言語)

## 変更内容

### バックエンド(`app/functions-go/github_stats.go` 新規)
- `GET githubStatsGo?user={screen_name}` — GitHub公開API(`/users/{login}` + `/users/{login}/repos` 最大300件)から取得・集計
- **フォークはスター・言語・代表リポジトリから除外**(本人の実績のみを見せる)
- キャッシュ2段構え:
  - Firestore(`github_stats` + `github_stats_fetched_at`)に**6時間**。GitHub障害時は期限切れでもstaleを返す(可用性優先)
  - CDN: `public, max-age=300, s-maxage=3600, stale-while-revalidate=86400`
- 認証は sanpaiGo と同じOAuth App資格情報のBasic認証(レート5000req/h)

### 配信・デプロイ
- `/githubStatsGo` の Hosting rewrite、dev/prod ワークフローにデプロイ追加(`$SANPAI_GH_CLIENT_ID/SECRET` を環境変数で注入)

### フロントエンド
- `web/components/GithubStats.vue` 新規。設置順: 参拝の記録 → **GitHubの実績** → 参拝の草

## 検証

- 集計純関数のユニットテスト(フォーク除外・言語ソート・top4・空でも`[]`)
- モックGitHubサーバーでページング(100件→2ページ目)・フィールド取得を検証
- エミュレータ統合: キャッシュヒット(GitHub非到達)・TTL切れ+GitHub 500→stale応答
- `yarn generate` 成功、ヘッドレスで描画確認(実績あり/ゼロ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_