### PR TITLE
README埋め込みバッジを追加(badgeGo)

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -269,6 +269,8 @@ jobs:
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           deploy profileStatsGo ProfileStatsGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
+          deploy badgeGo BadgeGo \
+            --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           # GitHub APIのレート制限緩和のため sanpaiGo と同じOAuth資格情報を使う
           deploy githubStatsGo GithubStatsGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=60s \

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -217,6 +217,8 @@ jobs:
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           deploy profileStatsGo ProfileStatsGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
+          deploy badgeGo BadgeGo \
+            --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s
           # GitHub APIのレート制限緩和のため sanpaiGo と同じOAuth資格情報を使う
           deploy githubStatsGo GithubStatsGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=60s \

--- a/app/firebase.json
+++ b/app/firebase.json
@@ -32,6 +32,10 @@
         "function": "githubStatsGo"
       },
       {
+        "source": "/badgeGo",
+        "function": "badgeGo"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/app/functions-go/badge.go
+++ b/app/functions-go/badge.go
@@ -1,0 +1,190 @@
+// README埋め込みバッジ(SVG)エンドポイント。
+//
+// shields.io 風のフラットバッジをSVGで生成する。GitHubのREADMEに
+//
+//	[![でばっぐ神社](https://d-shrine.jp/badgeGo?user=X)](https://d-shrine.jp/u/X)
+//
+// と貼ると「⛩ でばっぐ神社 | Lv.42 戦闘力 9999」が表示され、公開プロフィール
+// への導線になる。値は statusGo が書く status キャッシュ(level/total)から
+// 読むため、追加の重い集計は行わない。
+package gofunctions
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+)
+
+func init() {
+	functions.HTTP("BadgeGo", badgeHandler)
+}
+
+func badgeHandler(w http.ResponseWriter, r *http.Request) {
+	setCORSHeaders(w, r)
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Access-Control-Allow-Methods", "GET,OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type,Authorization")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	screenName := r.URL.Query().Get("user")
+	if screenName == "" {
+		writeError(w, http.StatusBadRequest, "user is required")
+		return
+	}
+
+	ctx := r.Context()
+	client, err := getFirestoreClient(ctx)
+	if err != nil {
+		log.Printf("badge: getFirestoreClient error: %v", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	if err := runBadge(ctx, w, client, screenName); err != nil {
+		log.Printf("badge: %v", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+	}
+}
+
+func runBadge(ctx context.Context, w http.ResponseWriter, client *firestore.Client, screenName string) error {
+	userDoc, err := findUserByScreenName(ctx, client, screenName)
+	if err != nil {
+		return err
+	}
+
+	// README内の画像はステータスコードが200以外だと壊れた画像アイコンになるため、
+	// 未登録ユーザーにも200で「未登録」バッジを返す(キャッシュは短め)。
+	if userDoc == nil {
+		writeBadgeSVG(w, badgeContent{Value: "未登録"}, time.Minute*5)
+		return nil
+	}
+
+	level := readCachedLevel(userDoc)
+	total := readCachedTotal(userDoc)
+	content := badgeContent{}
+	if level > 0 || total > 0 {
+		content.Value = fmt.Sprintf("Lv.%d 戦闘力 %d", level, total)
+	} else {
+		// statusキャッシュ未計算(未参拝 or 旧ユーザー)。参拝を促す。
+		content.Value = "参拝求ム"
+	}
+
+	// バッジはREADME閲覧のたびに読み込まれる。値の鮮度は重要でないため
+	// CDNに長めに載せ、関数・Firestoreへの到達を抑える。
+	writeBadgeSVG(w, content, time.Hour)
+	return nil
+}
+
+// readCachedTotal は status キャッシュから戦闘力(total)を取り出す。
+func readCachedTotal(userDoc *firestore.DocumentSnapshot) int {
+	v, err := userDoc.DataAt("status.total")
+	if err != nil {
+		return 0
+	}
+	if n, ok := v.(int64); ok {
+		return int(n)
+	}
+	return 0
+}
+
+type badgeContent struct {
+	Value string // 右側(色付き)セグメントの文言
+}
+
+func writeBadgeSVG(w http.ResponseWriter, content badgeContent, ttl time.Duration) {
+	svg := renderBadgeSVG("でばっぐ神社", content.Value)
+	w.Header().Set("Content-Type", "image/svg+xml; charset=utf-8")
+	w.Header().Set("Cache-Control", fmt.Sprintf(
+		"public, max-age=%d, s-maxage=%d, stale-while-revalidate=86400",
+		int(ttl.Seconds()), int(ttl.Seconds()),
+	))
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(svg))
+}
+
+// estimateBadgeTextWidth は Verdana 11px 相当の表示幅を概算する。
+// shields.io は実測メトリクスを持つが、ここでは ASCII≈7px・全角≈12px の
+// 近似で十分(バッジ内テキストは短く、多少の誤差は余白で吸収される)。
+func estimateBadgeTextWidth(s string) int {
+	width := 0
+	for _, r := range s {
+		if r <= 0x7F {
+			width += 7
+		} else {
+			width += 12
+		}
+	}
+	return width
+}
+
+// renderBadgeSVG は shields.io フラットスタイル風のバッジSVGを生成する。
+// 左: 鳥居アイコン+ラベル(グレー)、右: 値(神社の朱色)。
+func renderBadgeSVG(label, value string) string {
+	const (
+		height   = 20
+		pad      = 6  // セグメント両端の余白
+		iconW    = 13 // 鳥居アイコンの幅
+		iconGap  = 4  // アイコンとラベルの間
+		labelBG  = "#555"
+		valueBG  = "#c9302c" // 神社の朱色
+		textFill = "#fff"
+	)
+	labelTextW := estimateBadgeTextWidth(label)
+	valueTextW := estimateBadgeTextWidth(value)
+	labelW := pad + iconW + iconGap + labelTextW + pad
+	valueW := pad + valueTextW + pad
+	totalW := labelW + valueW
+
+	labelX := pad + iconW + iconGap + labelTextW/2
+	valueX := labelW + valueW/2
+
+	var b strings.Builder
+	fmt.Fprintf(&b, `<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" role="img" aria-label="%s: %s">`,
+		totalW, height, escapeXML(label), escapeXML(value))
+	fmt.Fprintf(&b, `<title>%s: %s</title>`, escapeXML(label), escapeXML(value))
+	// 角丸クリップ
+	fmt.Fprintf(&b, `<clipPath id="r"><rect width="%d" height="%d" rx="3" fill="#fff"/></clipPath>`, totalW, height)
+	fmt.Fprintf(&b, `<g clip-path="url(#r)">`)
+	fmt.Fprintf(&b, `<rect width="%d" height="%d" fill="%s"/>`, labelW, height, labelBG)
+	fmt.Fprintf(&b, `<rect x="%d" width="%d" height="%d" fill="%s"/>`, labelW, valueW, height, valueBG)
+	// shields風の上部ハイライト
+	fmt.Fprintf(&b, `<rect width="%d" height="%d" fill="url(#s)"/>`, totalW, height)
+	fmt.Fprintf(&b, `</g>`)
+	fmt.Fprintf(&b, `<linearGradient id="s" x2="0" y2="100%%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>`)
+	// 鳥居アイコン(笠木・島木・柱2本・額束)
+	fmt.Fprintf(&b, `<g fill="%s" transform="translate(%d,4)">`, textFill, pad)
+	b.WriteString(`<rect x="0" y="0" width="13" height="2" rx="0.5"/>`)   // 笠木
+	b.WriteString(`<rect x="1.5" y="3.6" width="10" height="1.4"/>`)      // 島木(貫)
+	b.WriteString(`<rect x="2.2" y="3.6" width="1.7" height="8.4"/>`)     // 左柱
+	b.WriteString(`<rect x="9.1" y="3.6" width="1.7" height="8.4"/>`)     // 右柱
+	b.WriteString(`<rect x="5.8" y="1.6" width="1.4" height="2.4"/>`)     // 額束
+	b.WriteString(`</g>`)
+	// テキスト(shields同様に影を敷いて読みやすく)
+	font := `font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11"`
+	fmt.Fprintf(&b, `<g fill="%s" text-anchor="middle" %s>`, textFill, font)
+	fmt.Fprintf(&b, `<text x="%d" y="15" fill="#010101" fill-opacity=".3">%s</text><text x="%d" y="14">%s</text>`,
+		labelX, escapeXML(label), labelX, escapeXML(label))
+	fmt.Fprintf(&b, `<text x="%d" y="15" fill="#010101" fill-opacity=".3">%s</text><text x="%d" y="14">%s</text>`,
+		valueX, escapeXML(value), valueX, escapeXML(value))
+	b.WriteString(`</g></svg>`)
+	return b.String()
+}
+
+func escapeXML(s string) string {
+	r := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+		"'", "&apos;",
+	)
+	return r.Replace(s)
+}

--- a/app/functions-go/badge_test.go
+++ b/app/functions-go/badge_test.go
@@ -1,0 +1,92 @@
+package gofunctions
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRenderBadgeSVG(t *testing.T) {
+	svg := renderBadgeSVG("でばっぐ神社", "Lv.42 戦闘力 9999")
+	for _, want := range []string{
+		"<svg", "でばっぐ神社", "Lv.42 戦闘力 9999", "#c9302c",
+		`role="img"`, "<title>",
+	} {
+		if !strings.Contains(svg, want) {
+			t.Errorf("svg missing %q", want)
+		}
+	}
+	// XMLエスケープ(値に記号が混ざっても壊れない)
+	esc := renderBadgeSVG("a&b", `<x>"y"`)
+	if strings.Contains(esc, "<x>") || !strings.Contains(esc, "&amp;b") {
+		t.Errorf("svg not escaped: %s", esc)
+	}
+}
+
+func TestEstimateBadgeTextWidth(t *testing.T) {
+	if w := estimateBadgeTextWidth("abc"); w != 21 {
+		t.Errorf("ascii width = %d, want 21", w)
+	}
+	if w := estimateBadgeTextWidth("神社"); w != 24 {
+		t.Errorf("cjk width = %d, want 24", w)
+	}
+	if w := estimateBadgeTextWidth(""); w != 0 {
+		t.Errorf("empty width = %d, want 0", w)
+	}
+}
+
+// エミュレータ統合: statusキャッシュあり/なし/未登録のバッジ出力。
+func TestBadge_Variants(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	// statusキャッシュあり
+	uid := "badge-test-user-1"
+	userRef := client.Collection("users").Doc(uid)
+	if _, err := userRef.Set(ctx, map[string]interface{}{
+		"screen_name": "badge-tester",
+		"status":      map[string]interface{}{"level": int64(42), "total": int64(9999)},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	t.Cleanup(func() { userRef.Delete(context.Background()) })
+
+	rec := httptest.NewRecorder()
+	if err := runBadge(ctx, rec, client, "badge-tester"); err != nil {
+		t.Fatalf("runBadge: %v", err)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "image/svg+xml; charset=utf-8" {
+		t.Errorf("Content-Type = %q", ct)
+	}
+	if !strings.Contains(rec.Body.String(), "Lv.42 戦闘力 9999") {
+		t.Errorf("badge body = %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Header().Get("Cache-Control"), "s-maxage=3600") {
+		t.Errorf("Cache-Control = %q", rec.Header().Get("Cache-Control"))
+	}
+
+	// statusキャッシュなし → 参拝求ム
+	uid2 := "badge-test-user-2"
+	userRef2 := client.Collection("users").Doc(uid2)
+	if _, err := userRef2.Set(ctx, map[string]interface{}{"screen_name": "badge-fresh"}); err != nil {
+		t.Fatalf("seed2: %v", err)
+	}
+	t.Cleanup(func() { userRef2.Delete(context.Background()) })
+	rec = httptest.NewRecorder()
+	if err := runBadge(ctx, rec, client, "badge-fresh"); err != nil {
+		t.Fatalf("runBadge fresh: %v", err)
+	}
+	if !strings.Contains(rec.Body.String(), "参拝求ム") {
+		t.Errorf("fresh badge = %s", rec.Body.String())
+	}
+
+	// 未登録 → 200で「未登録」バッジ(READMEで壊れた画像にしない)
+	rec = httptest.NewRecorder()
+	if err := runBadge(ctx, rec, client, "no-such-badge-user"); err != nil {
+		t.Fatalf("runBadge unknown: %v", err)
+	}
+	if rec.Code != 200 || !strings.Contains(rec.Body.String(), "未登録") {
+		t.Errorf("unknown badge: code=%d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -535,3 +535,24 @@ sanpai_logs / omikuji_logs を集計して返す(表示: `web/components/Profile
     **6時間**キャッシュ。GitHub障害時は期限切れでもstaleを返す(可用性優先)。
   - CDN: `public, max-age=300, s-maxage=3600, stale-while-revalidate=86400`
     (`/githubStatsGo` の Hosting rewrite 経由)。
+
+## READMEバッジエンドポイント badgeGo
+
+ポートフォリオ第四弾。`GET badgeGo?user={screen_name}` が shields.io 風の
+フラットバッジ(SVG)を返す。GitHubのプロフィールREADMEに
+
+```
+[![でばっぐ神社](https://d-shrine.jp/badgeGo?user=X)](https://d-shrine.jp/u/X)
+```
+
+と貼ると「⛩(鳥居アイコン) でばっぐ神社 | Lv.42 戦闘力 9999」が表示される
+(マイページにコピー用スニペットUIあり)。
+
+- 値は status キャッシュ(`status.level`/`status.total`)から読むだけで、
+  重い集計はしない。キャッシュ未計算は「参拝求ム」。
+- **未登録ユーザーにも200で「未登録」バッジを返す**(README内の画像は
+  非200だと壊れた画像アイコンになるため)。
+- テキスト幅は ASCII≈7px・全角≈12px の近似で算出(shields実測値の代替)。
+  鳥居アイコンは絵文字でなくSVGパスで描く(閲覧環境のフォント差の影響を受けない)。
+- キャッシュ: `public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400`
+  (未登録バッジのみ5分)。`/badgeGo` の Hosting rewrite 経由。

--- a/web/pages/dashboard/index.vue
+++ b/web/pages/dashboard/index.vue
@@ -116,6 +116,16 @@
         class="mt-4"
         :screen-name="user.screen_name"
       />
+      <!-- README埋め込みバッジ(自分のプロフィールへの導線をGitHubに貼れる) -->
+      <div v-if="user && user.screen_name" class="badge-section p-3 rounded mt-4">
+        <div class="fw-bold mb-2">🔖 READMEに貼れるバッジ</div>
+        <p class="badge-note mb-2">
+          GitHubのプロフィールREADMEに貼ると、レベルと戦闘力のバッジから
+          公開プロフィールへ飛べます。
+        </p>
+        <img :src="badgeUrl" alt="でばっぐ神社バッジ" height="20" class="mb-3" />
+        <ShareText title="" :text="badgeMarkdown"></ShareText>
+      </div>
     </div>
     <Loading v-if="isLoading" message="ヨミコミチュウ..."></Loading>
   </main>
@@ -196,6 +206,13 @@ export default {
     shareMessage() {
       return "これが" + this.user.display_name + "の でばっぐのうりょくだ！";
     },
+    // README用バッジ。画像はbadgeGo(SVG)、リンク先は公開プロフィール。
+    badgeUrl() {
+      return this.$config.baseUrl + "badgeGo?user=" + this.user.screen_name;
+    },
+    badgeMarkdown() {
+      return `[![でばっぐ神社](${this.badgeUrl})](${this.shareUrl})`;
+    },
     progressWidth() {
       return this.profile.exp.total / this.profile.next;
     },
@@ -207,6 +224,15 @@ export default {
 .profile-outline {
   background-color: #000;
   border-radius: 15px;
+}
+
+.badge-section {
+  background: #0d1117;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+.badge-note {
+  color: #9a9a9a;
+  font-size: 0.85rem;
 }
 
 .debug-title {


### PR DESCRIPTION
## 概要

ポートフォリオ第四弾。shields.io 風のフラットバッジ(SVG)を返す `badgeGo` を追加します。GitHubのプロフィールREADMEに

```md
[[でばっぐ神社](https://d-shrine.jp/badgeGo?user=X)](https://d-shrine.jp/u/X)
```

と貼ると **「⛩(鳥居アイコン) でばっぐ神社 | Lv.42 戦闘力 9999」** が表示され、公開プロフィールへの導線になります。

## 変更内容

### バックエンド(`app/functions-go/badge.go` 新規)
- `GET badgeGo?user={screen_name}` → SVGバッジ(左: 鳥居アイコン+ラベル、右: 朱色でLv・戦闘力)
- 値は status キャッシュから読むだけ(重い集計なし)。キャッシュ未計算は「参拝求ム」
- **未登録ユーザーにも200で「未登録」バッジ**(README内の画像は非200だと壊れた画像になるため)
- 鳥居アイコンは絵文字でなくSVGパスで描画(閲覧環境のフォント差の影響なし)
- テキスト幅は ASCII≈7px / 全角≈12px の近似で算出
- CDNキャッシュ: `s-maxage=3600`(未登録のみ5分)

### 配信・デプロイ
- `/badgeGo` の Hosting rewrite、dev/prod ワークフローにデプロイ追加

### フロントエンド
- マイページに **「🔖 READMEに貼れるバッジ」** セクション(プレビュー画像+Markdownコピー用の ShareText)

## 検証

- SVG生成・XMLエスケープ・幅推定のユニットテスト
- エミュレータ統合: statusキャッシュあり(Lv/戦闘力表示)/なし(参拝求ム)/未登録(200+未登録)/Content-Type/Cache-Control
- ヘッドレスChromiumで白背景・ダーク背景両方のレンダリング確認
- `yarn generate` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_