### PR TITLE
レーダーチャートを絶対値から割合(合計比%)表示に変更

### DIFF
--- a/app/functions-go/internal/ogpimage/ogpimage.go
+++ b/app/functions-go/internal/ogpimage/ogpimage.go
@@ -77,9 +77,12 @@ const (
 
 	gridLineWidth = 3.0
 	dataStrokeW   = 2.0
-	// グリッド(同心リング)の分割数。Chart.js の stepSize=10 相当は15本だが、
-	// 蜘蛛の巣状で見づらいため約半分の8本に減らしている。
-	radarGridSteps = 8
+	// レーダーは絶対値ではなく「5能力合計に占める割合(%)」で描く
+	// (能力値は参拝で単調増加するため、絶対値だとベテランは全軸振り切って
+	// バランスの形が見えない)。スケールは0〜50%固定・グリッドは10%刻み。
+	// Web側(web/components/charts/powerChart.vue)と同じ値にすること。
+	radarMaxPercent = 50
+	radarGridSteps  = 5
 
 	// 最終出力サイズ(OGP標準)。クロップ後にこのサイズへ一度だけ縮小する。
 	outputWidth  = 1200
@@ -197,14 +200,14 @@ func Render(p Params) (image.Image, error) {
 		drawTextTopScaled(dc, nameFace, line, statsX*scale, (statsY+lineHeight*float64(i))*scale, statsMaxWidth*scale)
 	}
 
-	// レーダーチャート
+	// レーダーチャート(Web側 powerChart.vue と同じく合計比の割合で描く)
 	drawRadar(dc, radarParams{
 		cx:         chartCenterX * scale,
 		cy:         chartCenterY * scale,
 		radius:     chartRadius * scale,
 		labelDist:  chartLabelDist * scale,
-		values:     [5]float64{float64(p.HP), float64(p.Power), float64(p.Intelligence), float64(p.Defence), float64(p.Agility)},
-		maxValue:   150,
+		values:     chartPercentages(p.HP, p.Power, p.Intelligence, p.Defence, p.Agility),
+		maxValue:   radarMaxPercent,
 		gridSteps:  radarGridSteps,
 		labels:     [5]string{"たいりょく", "ちから", "かしこさ", "しゅびりょく", "すばやさ"},
 		gridWidth:  gridLineWidth * scale,

--- a/app/functions-go/internal/ogpimage/radar.go
+++ b/app/functions-go/internal/ogpimage/radar.go
@@ -3,7 +3,8 @@
 //
 // Chart.js の radar 設定(app/functions/index.js の chartconfig)に対応:
 //   - 5軸(たいりょく/ちから/かしこさ/しゅびりょく/すばやさ)
-//   - min=0, max=150, グリッドは stepSize=10 ごと
+//   - 値は合計比の割合(%)、min=0, max=50%, グリッドは10%刻み
+//     (絶対値0-150から変更。ogpimage.go の radarMaxPercent 参照)
 //   - グリッド/軸線/ラベル色 rgb(242,242,242)
 //   - データ塗り rgba(0,168,228,0.6) / 枠線 rgb(0,117,159)
 //   - 頂点マーカー非表示
@@ -22,15 +23,34 @@ import (
 // radarParams はレーダーチャート1枚を描くためのピクセル指定。
 type radarParams struct {
 	cx, cy     float64    // 中心座標(px)
-	radius     float64    // max(=150)に対応する半径(px)
+	radius     float64    // maxValue に対応する半径(px)
 	labelDist  float64    // 中心からラベル中心までの距離(px)
 	values     [5]float64 // 各軸の値(0..maxValue)
-	maxValue   float64    // 満点(=150)
-	gridSteps  int        // 同心グリッドの分割数(Chart.js: max/stepSize = 150/10 = 15)
+	maxValue   float64    // 満点(現状は割合表示で50=50%)
+	gridSteps  int        // 同心グリッドの分割数
 	labels     [5]string
 	gridWidth  float64 // グリッド/軸線の線幅(px)
 	dataStroke float64 // データ枠線の線幅(px)
 	labelFace  font.Face
+}
+
+// chartPercentages は5能力の絶対値を「合計に占める割合(%)」へ正規化する(純関数)。
+// 合計0(未参拝)は全軸0のまま。Web側(dashboard / u/_userName)の割合化と
+// 同じ式にすること(round(v/total*100))。
+func chartPercentages(hp, power, intelligence, defence, agility int) [5]float64 {
+	raw := [5]float64{float64(hp), float64(power), float64(intelligence), float64(defence), float64(agility)}
+	total := 0.0
+	for _, v := range raw {
+		total += v
+	}
+	if total <= 0 {
+		return [5]float64{}
+	}
+	var pct [5]float64
+	for i, v := range raw {
+		pct[i] = math.Round(v / total * 100)
+	}
+	return pct
 }
 
 // axisAngle は軸 i の角度(ラジアン)を返す。頂点は真上(12時)始まりで時計回り

--- a/app/functions-go/internal/ogpimage/radar_test.go
+++ b/app/functions-go/internal/ogpimage/radar_test.go
@@ -1,0 +1,32 @@
+package ogpimage
+
+import "testing"
+
+func TestChartPercentages(t *testing.T) {
+	// バランス型: 各20%
+	pct := chartPercentages(100, 100, 100, 100, 100)
+	for i, v := range pct {
+		if v != 20 {
+			t.Errorf("balanced[%d] = %v, want 20", i, v)
+		}
+	}
+
+	// 特化型: power が過半を占める
+	pct = chartPercentages(10, 60, 10, 10, 10)
+	want := [5]float64{10, 60, 10, 10, 10}
+	if pct != want {
+		t.Errorf("specialized = %v, want %v", pct, want)
+	}
+
+	// 丸め: 1/3 ≈ 33%
+	pct = chartPercentages(1, 1, 1, 0, 0)
+	if pct[0] != 33 || pct[3] != 0 {
+		t.Errorf("rounding = %v", pct)
+	}
+
+	// 合計0(未参拝): 全軸0
+	pct = chartPercentages(0, 0, 0, 0, 0)
+	if pct != [5]float64{} {
+		t.Errorf("zero total = %v, want all 0", pct)
+	}
+}

--- a/app/functions-go/userogp.go
+++ b/app/functions-go/userogp.go
@@ -12,7 +12,7 @@
 //   - 表示名/アイコンは GitHub API ではなく Firestore の display_name / image_path を
 //     使用し、GitHub APIへの往復(レート制限リスク)を排除。
 //   - 出力を PNG から WebP(可逆VP8L)へ変更しファイルサイズを削減。
-//     キャッシュオブジェクトは ogps/{user}.webp。
+//     キャッシュオブジェクトは ogps/{user}{ogpObjectVersion}.webp(世代は ogpObjectName 参照)。
 package gofunctions
 
 import (
@@ -73,7 +73,7 @@ func userOGPHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	bucket := storageCli.Bucket(bucketName)
-	objectPath := fmt.Sprintf("ogps/%s.webp", username)
+	objectPath := "ogps/" + ogpObjectName(username)
 
 	// 既存キャッシュがあればそのURLへ。無ければ生成してからURLを得る。
 	exists, err := objectExists(ctx, bucket, objectPath)
@@ -244,9 +244,20 @@ func uploadObject(ctx context.Context, bucket *storage.BucketHandle, name, conte
 	return wc.Close()
 }
 
+// ogpObjectVersion はOGP画像キャッシュの世代。カードの描画内容を変えたら上げて
+// 旧キャッシュを無効化する(旧世代のオブジェクトは scheduled_ogp_delete が掃除する)。
+// v2: レーダーチャートを絶対値(0-150)から割合(合計比%・0-50%)表示に変更。
+const ogpObjectVersion = "_v2"
+
+// ogpObjectName はGCS上のOGP画像ファイル名(パス除く)を返す。
+// 保存側(userOGP)とURL生成側(ogpImageURL)で必ず同じ名前になるよう共通化している。
+func ogpObjectName(username string) string {
+	return username + ogpObjectVersion + ".webp"
+}
+
 // ogpImageURL は Firebase Storage のダウンロードURLを返す(Node版 getOgpUrl 相当、拡張子はwebp)。
 func ogpImageURL(bucketName, username string) string {
-	objectPath := "ogps%2F" + url.QueryEscape(username) + ".webp"
+	objectPath := "ogps%2F" + url.QueryEscape(ogpObjectName(username))
 	if host := os.Getenv("FIREBASE_STORAGE_EMULATOR_HOST"); host != "" && os.Getenv("FUNCTIONS_EMULATOR") != "" {
 		return fmt.Sprintf("http://%s/download/storage/v1/b/%s/o/%s?alt=media", host, bucketName, objectPath)
 	}

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -556,3 +556,21 @@ sanpai_logs / omikuji_logs を集計して返す(表示: `web/components/Profile
   鳥居アイコンは絵文字でなくSVGパスで描く(閲覧環境のフォント差の影響を受けない)。
 - キャッシュ: `public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400`
   (未登録バッジのみ5分)。`/badgeGo` の Hosting rewrite 経由。
+
+## レーダーチャート(でばっぐのうりょく)の割合表示
+
+能力値は参拝で単調増加するため、絶対値の固定スケール(0-150)ではベテランが
+全軸振り切った五角形になりバランスの形が見えなかった。そこで表示を
+**「5能力合計に占める割合(%)」** に正規化した(#159)。
+
+- 割合 = round(能力値 / 5能力合計 × 100)。合計0(未参拝)は全軸0。
+- スケールは **0〜50%固定**(グリッド10%刻み)・50%超はクランプ。
+  固定スケールなのでユーザー間で形を比較できる。
+- 正規化は**描画側のみ**で行い、APIレスポンス・`status` キャッシュの `chart` は
+  絶対値のまま(status_version のバンプ不要・後方互換)。
+  - Web: `web/pages/dashboard/index.vue` / `web/pages/u/_userName.vue` で正規化、
+    `web/components/charts/powerChart.vue` の max=50
+  - OGPカード: `internal/ogpimage` の `chartPercentages`(純関数)+ `radarMaxPercent`
+- OGP画像はGCSにキャッシュされるため、オブジェクト名を世代付き
+  (`ogps/{user}_v2.webp`、`userogp.go` の `ogpObjectName`)にして旧カードを無効化。
+  描画内容を変えるときはこの世代を上げること(旧世代は scheduled_ogp_delete が掃除)。

--- a/web/components/charts/powerChart.vue
+++ b/web/components/charts/powerChart.vue
@@ -20,7 +20,10 @@ export default {
           ticks: {
             display: false,
             min: 0,
-            max: 150,
+            // 値は絶対値ではなく「5能力合計に占める割合(%)」(呼び出し側で正規化)。
+            // バランス型は各軸20%の五角形、1能力が合計の半分を超える超特化は
+            // 頂点に張り付く。OGPカード(ogpimage の radarMaxPercent)と同じ値にすること。
+            max: 50,
           },
           gridLines: { color: "rgba(255, 255, 255, 0.7)" },
           angleLines: { color: "rgba(255, 255, 255, 0.7)" },

--- a/web/pages/dashboard/index.vue
+++ b/web/pages/dashboard/index.vue
@@ -170,13 +170,17 @@ export default {
       `statusGo?user=${this.user.screen_name}`
     );
     // 登録してなかったらエラーが出るのでエラー対応よろ
-    let userChart = [];
-    userChart.push(response.data.chart.hp);
-    userChart.push(response.data.chart.power);
-    userChart.push(response.data.chart.intelligence);
-    userChart.push(response.data.chart.defence);
-    userChart.push(response.data.chart.agility);
-    this.chartData.datasets[0].data = userChart;
+    // レーダーは絶対値でなく「5能力合計に占める割合(%)」で描く
+    // (powerChart.vue のスケール0〜50%・OGPカードと同じ正規化)。
+    const chart = response.data.chart;
+    const raw = [chart.hp, chart.power, chart.intelligence, chart.defence, chart.agility];
+    const chartTotal = raw.reduce((sum, v) => sum + v, 0);
+    // Chart.js v2 は max を超える値をクランプせず枠外へ描くため、
+    // スケール上限(50%)で明示的に切る(OGP側 drawRadar のクランプと同じ挙動)。
+    this.chartData.datasets[0].data =
+      chartTotal > 0
+        ? raw.map((v) => Math.min(50, Math.round((v / chartTotal) * 100)))
+        : raw;
 
     this.profile.total = response.data.total;
     this.profile.exp = response.data.total;

--- a/web/pages/u/_userName.vue
+++ b/web/pages/u/_userName.vue
@@ -176,13 +176,17 @@ export default {
     // Go版(statusGo)はコールドスタートが短く表示が速くなるため使用する
     // (Node版のstatusとレスポンス形式は同一。docs/backend.md参照)
     let response = await this.$axios.get("statusGo?user=" + this.$route.params.userName);
-    let userChart = [];
-    userChart.push(response.data.chart.hp);
-    userChart.push(response.data.chart.power);
-    userChart.push(response.data.chart.intelligence);
-    userChart.push(response.data.chart.defence);
-    userChart.push(response.data.chart.agility);
-    this.chartData.datasets[0].data = userChart;
+    // レーダーは絶対値でなく「5能力合計に占める割合(%)」で描く
+    // (powerChart.vue のスケール0〜50%・OGPカードと同じ正規化)。
+    const chart = response.data.chart;
+    const raw = [chart.hp, chart.power, chart.intelligence, chart.defence, chart.agility];
+    const chartTotal = raw.reduce((sum, v) => sum + v, 0);
+    // Chart.js v2 は max を超える値をクランプせず枠外へ描くため、
+    // スケール上限(50%)で明示的に切る(OGP側 drawRadar のクランプと同じ挙動)。
+    this.chartData.datasets[0].data =
+      chartTotal > 0
+        ? raw.map((v) => Math.min(50, Math.round((v / chartTotal) * 100)))
+        : raw;
 
     this.profile.nickName = response.data.user.display_name;
     this.profile.screenName = response.data.user.screen_name;


### PR DESCRIPTION
## 概要

でばっぐのうりょくのレーダーチャートは能力値の**絶対値を0〜150固定スケール**で描いていたため、能力値が参拝で単調増加する仕様上、ベテランは全軸振り切った「ただの五角形」になりバランスの形が見えませんでした。

各能力を**「5能力合計に占める割合(%)」**に正規化して描くよう変更します。バランス型は各軸20%の五角形、特化型はその方向に尖った形になり、ベテランも新人も同じスケールで形を比較できます。絶対値は隣の5能力テーブルにそのまま残ります。

## 変更内容

- 割合 = round(能力値 / 5能力合計 × 100)。合計0(未参拝)は全軸0
- スケール **0〜50%固定**(グリッド10%刻み)。50%超(超特化)はクランプ — Chart.js v2はmax超えを枠外に描いてしまうため明示的に切る
- **正規化は描画側のみ**。APIレスポンス・Firestoreの `status.chart` は絶対値のまま(status_versionバンプ不要・後方互換)

### Web
- `web/pages/dashboard/index.vue` / `web/pages/u/_userName.vue`: chart値を割合化
- `web/components/charts/powerChart.vue`: スケール max 150 → 50

### OGPカード(Go)
- `internal/ogpimage`: `chartPercentages`(純関数)で正規化、`radarMaxPercent=50`・グリッド10%刻み
- `userogp.go`: GCSキャッシュのオブジェクト名を世代付き **`ogps/{user}_v2.webp`** に変更(`ogpObjectName` に集約)。旧カードは即座に無効化され、残骸は既存の scheduled_ogp_delete が掃除

## 検証

- `chartPercentages` ユニットテスト(バランス/特化/丸め/合計0)+ `go test ./...` 全パス
- OGP QCサンプル(`TestWriteQCArtifacts`)をローカル生成し、割合レーダーの描画を目視確認
- ヘッドレスChromium + Chart.js 2.8 で バランス型/超特化/新規/全0 の4パターン描画確認(この検証で v2 がクランプしないことを発見し、Math.min(50, ...) を追加)
- `yarn generate` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_