### PR TITLE
プロフィールのシェア文面がundefinedになる問題を修正

### DIFF
--- a/web/pages/u/_userName.vue
+++ b/web/pages/u/_userName.vue
@@ -185,18 +185,25 @@ export default {
     this.chartData.datasets[0].data =
       chartMax > 0 ? raw.map((v) => Math.round((v / chartMax) * 100)) : raw;
 
-    this.profile.nickName = response.data.user.display_name;
-    this.profile.screenName = response.data.user.screen_name;
-    this.profile.profileImage = response.data.user.github_image_path;
-    this.status.level = response.data.level;
-    this.status.points = response.data.points;
-    this.status.total = response.data.total;
-    this.status.hp = response.data.hp;
-    this.status.power = response.data.power;
-    this.status.intelligence = response.data.intelligence;
-    this.status.defence = response.data.defence;
-    this.status.agility = response.data.agility;
-    this.status.last_sanpai = response.data.last_sanpai;
+    // dataの空オブジェクトへの後付けプロパティ追加はVue 2では検知されず、
+    // computed(shareMessage等)が初回値のまま固定される。オブジェクトごと
+    // 差し替えてリアクティブにする(#165)。
+    this.profile = {
+      nickName: response.data.user.display_name,
+      screenName: response.data.user.screen_name,
+      profileImage: response.data.user.github_image_path,
+    };
+    this.status = {
+      level: response.data.level,
+      points: response.data.points,
+      total: response.data.total,
+      hp: response.data.hp,
+      power: response.data.power,
+      intelligence: response.data.intelligence,
+      defence: response.data.defence,
+      agility: response.data.agility,
+      last_sanpai: response.data.last_sanpai,
+    };
     if(response){
       this.isLoading = false;
     }


### PR DESCRIPTION
Closes #165

## 原因

`u/_userName.vue` が `data` の空オブジェクト `profile: {}` / `status: {}` に後からプロパティを追加しており、Vue 2はオブジェクトへのプロパティ追加を検知できないため、computed の `shareMessage` が初回評価時の `undefined` のままキャッシュされていた(Issueの分析どおり)。

## 修正

Issueで推奨した**オブジェクトごと差し替え**方式。API応答受領時に `this.profile = {...}` / `this.status = {...}` と丸ごと代入してリアクティブにする。`status` は現状computedから参照されていないが、同じ罠を残さないため併せて修正。

## 検証(ローカル・実ブラウザ/Playwright)

修正前: `これがundefinedの でばっぐのうりょくだ！`
修正後:

- Xシェア文面: `これがOtter Orangeの でばっぐのうりょくだ！` ✅
- クリップボードコピー: `これがOtter Orangeの でばっぐのうりょくだ！\nhttp://localhost:3000/u/ShinoharaTa` ✅
- プロフィール表示(名前・画像・ステータス値)に変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)