### PR TITLE
おみくじの抽選を物理乱数(kuda)化

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -277,7 +277,7 @@ jobs:
             --set-env-vars="GITHUB_CLIENT_ID=$SANPAI_GH_CLIENT_ID,GITHUB_CLIENT_SECRET=$SANPAI_GH_CLIENT_SECRET"
           deploy omikujiGo OmikujiGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s \
-            --set-env-vars="OMIKUJI_COOLDOWN_SECONDS=60"
+            --set-env-vars="OMIKUJI_COOLDOWN_SECONDS=60,KUDA_BASE_URL=https://kuda.kojiran.workers.dev"
           deploy ogpRewriteGo OgpRewriteGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s \
             --set-env-vars="FUNC_BASE_URL=$OGP_FUNC_BASE_URL,OGP_PROJECT_ID=d-shrine-dev"

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -225,7 +225,7 @@ jobs:
             --set-env-vars="GITHUB_CLIENT_ID=$SANPAI_GH_CLIENT_ID,GITHUB_CLIENT_SECRET=$SANPAI_GH_CLIENT_SECRET"
           deploy omikujiGo OmikujiGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s \
-            --set-env-vars="OMIKUJI_COOLDOWN_SECONDS=28800"
+            --set-env-vars="OMIKUJI_COOLDOWN_SECONDS=28800,KUDA_BASE_URL=https://kuda.kojiran.workers.dev"
           deploy ogpRewriteGo OgpRewriteGo \
             --trigger-http --allow-unauthenticated --memory=256Mi --timeout=30s \
             --set-env-vars="FUNC_BASE_URL=$OGP_FUNC_BASE_URL,OGP_PROJECT_ID=d-shrine"

--- a/app/functions-go/kuda.go
+++ b/app/functions-go/kuda.go
@@ -1,0 +1,136 @@
+// kuda(乱数の管)クライアント。
+//
+// 428lab/kuda は ANU の量子真空ゆらぎと自宅ガイガーカウンター(放射性崩壊)の
+// 物理エントロピーをプールし、GET /drop で1バイトずつ払い出すAPI。
+// おみくじの抽選をこの物理乱数で行う(docs/backend.md「おみくじの物理乱数化」)。
+//
+// kudaの原則に合わせたクライアント側の約束:
+//   - 引いた値の拒否(rejection sampling)はしない。値→確率の写像はスケーリングのみ。
+//   - プール枯渇(503)や停止時に疑似乱数へフォールバックしない。呼び出し元が
+//     「引けない」を表現する(omikuji の no_entropy)。
+//   - レスポンスは no-store。こちらでもキャッシュ・再利用しない。
+package gofunctions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+// kudaBaseURL は kuda API のベースURL。環境変数 KUDA_BASE_URL で上書き可能で、
+// テストでは httptest サーバーに差し替える(初期化は resolveKudaBaseURL 参照)。
+var kudaBaseURL = resolveKudaBaseURL()
+
+func resolveKudaBaseURL() string {
+	if v := os.Getenv("KUDA_BASE_URL"); v != "" {
+		return v
+	}
+	return "https://kuda.kojiran.workers.dev"
+}
+
+var kudaHTTPClient = &http.Client{}
+
+// kudaFetchTimeout は /drop 一式の取得に許す時間。おみくじは演出中に呼ばれる
+// ため多少待てるが、Workersが応答しない場合に抽選を長く塞がないよう短めにする。
+const kudaFetchTimeout = 4 * time.Second
+
+// kudaDrop は GET /drop のレスポンス。
+type kudaDrop struct {
+	Value         int    `json:"value"`    // 0-255
+	DropSeq       int64  `json:"drop_seq"`
+	PoolSeq       int64  `json:"pool_seq"`
+	Batch         string `json:"batch"` // 出自ラベル(anu#… / home#…)
+	DrawnAt       string `json:"drawn_at"`
+	PoolRemaining int64  `json:"pool_remaining"`
+}
+
+// fetchKudaBytes は /drop を並列に n 回呼び、n バイトの物理乱数を取得する。
+// 1つでも失敗(503含む)したら全体を error にする。取得済みバイトは kuda 側で
+// 消費済み(不可逆)だが、抽選に使わず捨てるだけなので公平性には影響しない。
+func fetchKudaBytes(ctx context.Context, n int) ([]kudaDrop, error) {
+	ctx, cancel := context.WithTimeout(ctx, kudaFetchTimeout)
+	defer cancel()
+
+	type result struct {
+		idx  int
+		drop kudaDrop
+		err  error
+	}
+	ch := make(chan result, n)
+	for i := 0; i < n; i++ {
+		go func(idx int) {
+			drop, err := fetchKudaDrop(ctx)
+			ch <- result{idx: idx, drop: drop, err: err}
+		}(i)
+	}
+
+	drops := make([]kudaDrop, n)
+	for i := 0; i < n; i++ {
+		res := <-ch
+		if res.err != nil {
+			return nil, res.err
+		}
+		drops[res.idx] = res.drop
+	}
+	return drops, nil
+}
+
+func fetchKudaDrop(ctx context.Context) (kudaDrop, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, kudaBaseURL+"/drop", nil)
+	if err != nil {
+		return kudaDrop{}, err
+	}
+	req.Header.Set("User-Agent", "debug-shrine-omikujiGo")
+
+	resp, err := kudaHTTPClient.Do(req)
+	if err != nil {
+		return kudaDrop{}, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return kudaDrop{}, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		// 503 = プール枯渇。それ以外も「物理乱数が用意できない」として同じ扱い。
+		return kudaDrop{}, fmt.Errorf("kuda /drop: status %d: %s", resp.StatusCode, string(body))
+	}
+	var drop kudaDrop
+	if err := json.Unmarshal(body, &drop); err != nil {
+		return kudaDrop{}, err
+	}
+	if drop.Value < 0 || drop.Value > 255 {
+		return kudaDrop{}, fmt.Errorf("kuda /drop: value out of range: %d", drop.Value)
+	}
+	return drop, nil
+}
+
+// bytesToUnitFloat は2バイトを r∈[0,1) に写像する(純関数)。
+// 65536段階なので tier 重み(合計100)に対する量子化誤差は無視できる。
+func bytesToUnitFloat(hi, lo int) float64 {
+	return float64(hi*256+lo) / 65536.0
+}
+
+// byteToUnitFloat は1バイトを r∈[0,1) に写像する(純関数)。
+// 文言プール(レア度ごと15件)の選択用途には256段階で十分。
+func byteToUnitFloat(b int) float64 {
+	return float64(b) / 256.0
+}
+
+// dedupBatches は drops の出自ラベルを順序を保って重複除去する。
+func dedupBatches(drops []kudaDrop) []string {
+	seen := map[string]bool{}
+	batches := make([]string, 0, len(drops))
+	for _, d := range drops {
+		if d.Batch == "" || seen[d.Batch] {
+			continue
+		}
+		seen[d.Batch] = true
+		batches = append(batches, d.Batch)
+	}
+	return batches
+}

--- a/app/functions-go/kuda_test.go
+++ b/app/functions-go/kuda_test.go
@@ -1,0 +1,117 @@
+package gofunctions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// kudaMock はテスト用のkudaモックサーバー。kudaBaseURL を差し替え、
+// テスト終了時に元へ戻す。
+type kudaMock struct {
+	Calls    int64 // /drop が呼ばれた回数
+	Depleted bool  // true にすると503(プール枯渇)を返す
+	server   *httptest.Server
+}
+
+func mockKuda(t *testing.T) *kudaMock {
+	t.Helper()
+	m := &kudaMock{}
+	m.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/drop" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		n := atomic.AddInt64(&m.Calls, 1)
+		if m.Depleted {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, `{"error":"pool depleted"}`)
+			return
+		}
+		w.Header().Set("Cache-Control", "no-store")
+		json.NewEncoder(w).Encode(kudaDrop{
+			Value:   int((n * 37) % 256), // 呼び出しごとに変わる決定的な値
+			DropSeq: n,
+			PoolSeq: 1000 + n,
+			Batch:   "anu#test-batch",
+		})
+	}))
+	orig := kudaBaseURL
+	kudaBaseURL = m.server.URL
+	t.Cleanup(func() {
+		kudaBaseURL = orig
+		m.server.Close()
+	})
+	return m
+}
+
+func TestBytesToUnitFloat(t *testing.T) {
+	for _, tc := range []struct {
+		hi, lo int
+		want   float64
+	}{
+		{0, 0, 0},
+		{128, 0, 0.5},
+		{255, 255, 65535.0 / 65536.0},
+	} {
+		if got := bytesToUnitFloat(tc.hi, tc.lo); got != tc.want {
+			t.Errorf("bytesToUnitFloat(%d,%d) = %v, want %v", tc.hi, tc.lo, got, tc.want)
+		}
+	}
+	if got := byteToUnitFloat(255); got >= 1 || got != 255.0/256.0 {
+		t.Errorf("byteToUnitFloat(255) = %v", got)
+	}
+	// r<1 が保証されるので drawTierByValue / pickEntryByValue の範囲内に収まる
+	if tier := drawTierByValue(bytesToUnitFloat(255, 255)); tier != TierDaikyo {
+		t.Errorf("max bytes → tier %q, want %q (末尾レア度)", tier, TierDaikyo)
+	}
+}
+
+func TestDedupBatches(t *testing.T) {
+	drops := []kudaDrop{
+		{Batch: "anu#a"}, {Batch: "home#b"}, {Batch: "anu#a"}, {Batch: ""},
+	}
+	got := dedupBatches(drops)
+	if len(got) != 2 || got[0] != "anu#a" || got[1] != "home#b" {
+		t.Errorf("dedupBatches = %v", got)
+	}
+}
+
+func TestFetchKudaBytes(t *testing.T) {
+	m := mockKuda(t)
+	drops, err := fetchKudaBytes(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("fetchKudaBytes: %v", err)
+	}
+	if len(drops) != 3 || m.Calls != 3 {
+		t.Fatalf("drops=%d calls=%d, want 3/3", len(drops), m.Calls)
+	}
+	for _, d := range drops {
+		if d.Value < 0 || d.Value > 255 || d.Batch == "" {
+			t.Errorf("bad drop: %+v", d)
+		}
+	}
+
+	// 枯渇時はエラー
+	m.Depleted = true
+	if _, err := fetchKudaBytes(context.Background(), 3); err == nil {
+		t.Error("depleted pool should return error")
+	}
+}
+
+func TestFetchKudaBytes_Unreachable(t *testing.T) {
+	orig := kudaBaseURL
+	kudaBaseURL = "http://127.0.0.1:1" // 接続不能
+	t.Cleanup(func() { kudaBaseURL = orig })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := fetchKudaBytes(ctx, 3); err == nil {
+		t.Error("unreachable kuda should return error")
+	}
+}

--- a/app/functions-go/omikuji.go
+++ b/app/functions-go/omikuji.go
@@ -12,7 +12,6 @@ package gofunctions
 import (
 	"context"
 	"log"
-	"math/rand"
 	"net/http"
 	"os"
 	"strconv"
@@ -246,8 +245,23 @@ func runOmikuji(ctx context.Context, w http.ResponseWriter, client *firestore.Cl
 		return nil
 	}
 
-	tier := drawTierByValue(rand.Float64())
-	entry, ok := pickEntryByValue(tier, rand.Float64())
+	// 抽選は kuda の物理乱数(量子ゆらぎ/放射性崩壊)で行う。1回の抽選で
+	// 3バイト消費: tier に2バイト(重み合計100に対し量子化誤差~0.003%)、
+	// 文言に1バイト(プール15件のflavor用途)。
+	// kuda が枯渇(503)・停止中は疑似乱数へフォールバックせず「引けない」を
+	// 返す(ユーザー決定。クールダウンは消費しないので復旧後に引き直せる)。
+	drops, err := fetchKudaBytes(ctx, 3)
+	if err != nil {
+		log.Printf("omikuji: kuda unavailable: %v", err)
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"status":  "no_entropy",
+			"message": "physical entropy unavailable",
+		})
+		return nil
+	}
+
+	tier := drawTierByValue(bytesToUnitFloat(drops[0].Value, drops[1].Value))
+	entry, ok := pickEntryByValue(tier, byteToUnitFloat(drops[2].Value))
 	if !ok {
 		// データ不備(そのレア度のエントリが存在しない)。異常系として扱う。
 		return errNoEntryForTier(tier)
@@ -258,6 +272,11 @@ func runOmikuji(ctx context.Context, w http.ResponseWriter, client *firestore.Cl
 		"tier":    entry.Tier,
 		"fortune": entry.Fortune,
 		"lines":   linesToMaps(entry.Lines),
+		// 出自(結果カードに「物理乱数が決めた」ことを表示するため保存にも含める)
+		"entropy": map[string]interface{}{
+			"source":  "physical",
+			"batches": dedupBatches(drops),
+		},
 	}
 
 	if _, err := userRef.Update(ctx, []firestore.Update{
@@ -269,10 +288,12 @@ func runOmikuji(ctx context.Context, w http.ResponseWriter, client *firestore.Cl
 
 	// 統計・称号用の履歴(読み手: profileStatsGo)。sanpai_logs と同じ流儀で
 	// 1回の抽選ごとに1ドキュメント残す。導入以前の抽選は遡れない。
+	// entropy_batches は物理乱数の出自(監査用。kudaのバッチラベル)。
 	if _, _, err := userRef.Collection("omikuji_logs").Add(ctx, map[string]interface{}{
-		"entry_id":  entry.ID,
-		"tier":      entry.Tier,
-		"timestamp": firestore.ServerTimestamp,
+		"entry_id":        entry.ID,
+		"tier":            entry.Tier,
+		"timestamp":       firestore.ServerTimestamp,
+		"entropy_batches": dedupBatches(drops),
 	}); err != nil {
 		return err
 	}

--- a/app/functions-go/omikuji_integration_test.go
+++ b/app/functions-go/omikuji_integration_test.go
@@ -22,6 +22,7 @@ func decodeOmikujiResp(t *testing.T, rec *httptest.ResponseRecorder) map[string]
 
 func TestOmikuji_RunOmikuji_PeekDrawCooldown(t *testing.T) {
 	client := emulatorClient(t)
+	kuda := mockKuda(t)
 	ctx := context.Background()
 	t.Setenv("OMIKUJI_COOLDOWN_SECONDS", "3600")
 
@@ -34,13 +35,16 @@ func TestOmikuji_RunOmikuji_PeekDrawCooldown(t *testing.T) {
 
 	body := omikujiRequestBody{GithubID: uid}
 
-	// 1) peek: 未抽選なので available
+	// 1) peek: 未抽選なので available。kuda(物理乱数)は消費しない
 	rec := httptest.NewRecorder()
 	if err := runOmikuji(ctx, rec, client, omikujiRequestBody{GithubID: uid, Peek: true}); err != nil {
 		t.Fatalf("runOmikuji peek: %v", err)
 	}
 	if got := decodeOmikujiResp(t, rec)["status"]; got != "available" {
 		t.Fatalf("peek status = %v, want available", got)
+	}
+	if kuda.Calls != 0 {
+		t.Errorf("peek should not consume kuda bytes (calls=%d)", kuda.Calls)
 	}
 
 	// 2) draw: success + 結果 + 保存
@@ -55,6 +59,17 @@ func TestOmikuji_RunOmikuji_PeekDrawCooldown(t *testing.T) {
 	result, ok := resp["result"].(map[string]interface{})
 	if !ok || result["tier"] == "" || result["fortune"] == "" {
 		t.Fatalf("draw result missing tier/fortune: %v", resp["result"])
+	}
+	// 抽選は3バイト消費し、結果に出自(entropy)が付く
+	if kuda.Calls != 3 {
+		t.Errorf("draw should consume 3 kuda bytes (calls=%d)", kuda.Calls)
+	}
+	entropy, ok := result["entropy"].(map[string]interface{})
+	if !ok || entropy["source"] != "physical" {
+		t.Errorf("result entropy = %v, want source=physical", result["entropy"])
+	}
+	if batches, ok := entropy["batches"].([]interface{}); !ok || len(batches) == 0 {
+		t.Errorf("entropy batches = %v, want non-empty", entropy["batches"])
 	}
 	// 保存確認
 	snap, err := userRef.Get(ctx)
@@ -82,6 +97,49 @@ func TestOmikuji_RunOmikuji_PeekDrawCooldown(t *testing.T) {
 	}
 	if _, ok := resp2["result"].(map[string]interface{}); !ok {
 		t.Errorf("cooldown response should include previous result")
+	}
+}
+
+// kuda(物理乱数)が枯渇・停止しているときは疑似乱数へフォールバックせず
+// no_entropy を返し、クールダウン(last_omikuji)を消費しない。
+func TestOmikuji_RunOmikuji_NoEntropy(t *testing.T) {
+	client := emulatorClient(t)
+	kuda := mockKuda(t)
+	kuda.Depleted = true
+	ctx := context.Background()
+	t.Setenv("OMIKUJI_COOLDOWN_SECONDS", "3600")
+
+	uid := "omikuji-test-user-3"
+	userRef := client.Collection("users").Doc(uid)
+	if _, err := userRef.Set(ctx, map[string]interface{}{"screen_name": "tester3"}); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() { userRef.Delete(context.Background()) })
+
+	rec := httptest.NewRecorder()
+	if err := runOmikuji(ctx, rec, client, omikujiRequestBody{GithubID: uid}); err != nil {
+		t.Fatalf("runOmikuji: %v", err)
+	}
+	if got := decodeOmikujiResp(t, rec)["status"]; got != "no_entropy" {
+		t.Fatalf("status = %v, want no_entropy", got)
+	}
+	// クールダウンは消費されない(復旧後にすぐ引き直せる)
+	snap, err := userRef.Get(ctx)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if _, err := snap.DataAt("last_omikuji"); err == nil {
+		t.Error("last_omikuji should NOT be written on no_entropy")
+	}
+
+	// 復旧したら普通に引ける
+	kuda.Depleted = false
+	rec = httptest.NewRecorder()
+	if err := runOmikuji(ctx, rec, client, omikujiRequestBody{GithubID: uid}); err != nil {
+		t.Fatalf("runOmikuji after recovery: %v", err)
+	}
+	if got := decodeOmikujiResp(t, rec)["status"]; got != "success" {
+		t.Errorf("status after recovery = %v, want success", got)
 	}
 }
 

--- a/app/functions-go/profile_stats_integration_test.go
+++ b/app/functions-go/profile_stats_integration_test.go
@@ -100,6 +100,7 @@ func TestProfileStats_Basic(t *testing.T) {
 // おみくじを引くと omikuji_logs が書かれる(profileStatsGoのデータ源になる)ことの確認。
 func TestOmikuji_WritesLog(t *testing.T) {
 	client := emulatorClient(t)
+	mockKuda(t)
 	ctx := context.Background()
 	t.Setenv("OMIKUJI_COOLDOWN_SECONDS", "3600")
 
@@ -134,5 +135,8 @@ func TestOmikuji_WritesLog(t *testing.T) {
 	data := docs[0].Data()
 	if data["tier"] == "" || data["entry_id"] == "" || data["timestamp"] == nil {
 		t.Errorf("omikuji_log fields missing: %v", data)
+	}
+	if batches, ok := data["entropy_batches"].([]interface{}); !ok || len(batches) == 0 {
+		t.Errorf("omikuji_log entropy_batches missing: %v", data["entropy_batches"])
 	}
 }

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -576,3 +576,38 @@ sanpai_logs / omikuji_logs を集計して返す(表示: `web/components/Profile
 - OGP画像はGCSにキャッシュされるため、オブジェクト名を世代付き
   (`ogps/{user}_v3.webp`、`userogp.go` の `ogpObjectName`)にして旧カードを無効化。
   描画内容を変えるときはこの世代を上げること(旧世代は scheduled_ogp_delete が掃除)。
+
+## おみくじの物理乱数化(kuda)
+
+おみくじの抽選乱数を Go の `math/rand`(疑似乱数)から 428lab/kuda
+(https://kuda.kojiran.workers.dev)の**物理エントロピー**に置き換えた。
+kuda は ANU の量子真空ゆらぎ+ガイガーカウンター(放射性崩壊)をプールし、
+`GET /drop` で1バイトずつ払い出す(消費したバイトは不可逆削除)。
+
+### kudaの原則に対するこちらの振る舞い
+
+- **引いた値の拒否(rejection sampling)はしない**。値→確率の写像は
+  スケーリングのみ(`bytesToUnitFloat` / `byteToUnitFloat`)。
+- **疑似乱数へフォールバックしない**。枯渇(503)・停止・タイムアウト時は
+  `{status:"no_entropy"}` を返し、フロントは「御籤の源が尽きておる」を表示。
+  このとき `last_omikuji` は書かない=クールダウンを消費しないので、
+  補充後すぐ引き直せる。
+- peek(状態確認)はkudaに触れない。バイトを消費するのは実際の抽選だけ。
+
+### バイト割当とエントロピー収支
+
+- 1回の抽選 = **3バイト**: tier に2バイト(重み合計100に対する量子化誤差
+  ~0.003%)、文言に1バイト(レア度ごと15件のflavor用途)。
+- kudaのプールは1日1024バイト(ANU cron)+home注入 ≒ 約340回/日の抽選。
+  クールダウン8hの現ユーザー規模では十分。
+- `/drop` は並列3コール・全体タイムアウト4秒(`kuda.go`)。
+
+### 出自の記録・表示
+
+- 結果(`omikuji_result` 保存含む)に `entropy: {source:"physical",
+  batches:[...]}`(kudaのバッチラベル。重複除去済み)を付与し、
+  結果カード下部に「⚛️ この御籤は量子ゆらぎと放射性崩壊(物理乱数)が
+  決めました」+バッチを表示する。導入前の結果には entropy が無く非表示。
+- `omikuji_logs` にも `entropy_batches` を記録(監査用)。
+- 接続先は env `KUDA_BASE_URL`(dev/prod とも本番kudaを使用。テストは
+  httptest モックで実プールを消費しない)。

--- a/web/components/OmikujiResult.vue
+++ b/web/components/OmikujiResult.vue
@@ -14,6 +14,16 @@
           <span class="txt">{{ l.text }}</span>
         </li>
       </ul>
+
+      <!-- 物理乱数の出自(kudaで引いたときだけ表示) -->
+      <div v-if="isPhysical" class="entropy">
+        <div>⚛️ この御籤は量子ゆらぎと放射性崩壊(物理乱数)が決めました</div>
+        <div class="entropy-batches">
+          <span v-for="b in result.entropy.batches" :key="b" class="entropy-batch">{{
+            b
+          }}</span>
+        </div>
+      </div>
     </div>
   </transition>
 </template>
@@ -36,6 +46,14 @@ export default {
   computed: {
     meta() {
       return META[this.result.tier] || { key: "chukichi", emoji: "🔮", accent: "#888" };
+    },
+    // kuda(物理乱数)で引いた結果のみ true。導入前の保存結果には entropy が無い。
+    isPhysical() {
+      return (
+        this.result.entropy &&
+        this.result.entropy.source === "physical" &&
+        Array.isArray(this.result.entropy.batches)
+      );
     },
   },
 };
@@ -109,6 +127,29 @@ export default {
   color: #3a2f28;
   font-size: 0.98rem;
   line-height: 1.55;
+}
+
+/* 物理乱数の出自 */
+.entropy {
+  border-top: 1px dashed rgba(0, 0, 0, 0.12);
+  margin: 0 16px;
+  padding: 10px 0 14px;
+  color: #8a7f74;
+  font-size: 0.74rem;
+  line-height: 1.5;
+}
+.entropy-batches {
+  margin-top: 4px;
+}
+.entropy-batch {
+  display: inline-block;
+  font-family: SFMono-Regular, Consolas, Menlo, monospace;
+  font-size: 0.68rem;
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 4px;
+  padding: 1px 6px;
+  margin-right: 4px;
+  word-break: break-all;
 }
 
 /* レア度ごとの縁取り */

--- a/web/pages/omikuji.vue
+++ b/web/pages/omikuji.vue
@@ -57,6 +57,21 @@
       次に引けるまで <span class="fw-bold">{{ remainingText }}</span>
     </div>
 
+    <!-- 物理乱数(kuda)が枯渇・停止中。疑似乱数では引かない -->
+    <div v-else-if="state === 'empty'" class="my-5">
+      <div class="fs-1">⚛️</div>
+      <div class="fs-4 mt-3">
+        「御籤の源(物理乱数)が尽きておる…<br class="d-md-none" />しばし待たれよ。」
+      </div>
+      <p class="text-muted mt-2 small">
+        この神社のおみくじは量子ゆらぎと放射性崩壊の実測値だけで引かれます。
+        エントロピーが補充されるまでお待ちください。
+      </p>
+      <button class="btn btn-outline-secondary mt-2" @click="fetchStatus">
+        もう一度確かめる
+      </button>
+    </div>
+
     <!-- 抽選演出(鈴の緒 → 連鎖 → 狐が選ぶ)。全画面オーバーレイ -->
     <OmikujiScene
       v-if="state === 'animating'"
@@ -87,7 +102,7 @@ export default {
   components: { ResultCard, OmikujiScene },
   data() {
     return {
-      state: "loading", // loading | available | animating | cooldown | error
+      state: "loading", // loading | available | animating | cooldown | empty(物理乱数枯渇) | error
       result: null,
       pendingResult: null, // 演出中に保持(着地まで表示しない)
       remaining: 0, // 次に引けるまでの秒
@@ -186,6 +201,10 @@ export default {
         this.startTimer();
       } else if (d.status === "available") {
         this.state = "available";
+      } else if (d.status === "no_entropy") {
+        // 物理乱数(kuda)が枯渇・停止中。クールダウンは消費されていないので
+        // 補充され次第また引ける。
+        this.state = "empty";
       } else {
         // not registered / failed など
         this.state = "error";


### PR DESCRIPTION
## 概要

おみくじの抽選乱数を `math/rand`(疑似乱数)から **428lab/kuda**(https://kuda.kojiran.workers.dev)の**物理エントロピー**(ANU量子真空ゆらぎ+ガイガーカウンターの放射性崩壊)に置き換えます。

## kudaの原則への追従

- **値の拒否(rejection sampling)はしない** — 写像はスケーリングのみ(`bytesToUnitFloat`)。既存の `drawTierByValue` / `pickEntryByValue` をそのまま使用
- **疑似乱数へフォールバックしない** — 枯渇(503)・停止・タイムアウト時は `{status:"no_entropy"}` を返し、フロントは「⚛️ 御籤の源(物理乱数)が尽きておる…しばし待たれよ。」を表示。**`last_omikuji` は書かない=クールダウン非消費**なので補充後すぐ引き直せます
- peek(状態確認)はkudaに触れず、バイトを消費するのは実抽選のみ

## 変更内容

### バックエンド
- 新規 `app/functions-go/kuda.go`: `GET /drop` を並列3コール(全体タイムアウト4秒)。`KUDA_BASE_URL` で差し替え可能
- `omikuji.go`: 1回の抽選=**3バイト消費**(tier 2バイト: 重み合計100への量子化誤差~0.003% / 文言 1バイト)。結果と `omikuji_logs` に出自(`entropy.batches` = kudaのバッチラベル)を記録
- エントロピー収支: プール1024バイト/日+home注入 ≒ 約340回/日の抽選が可能

### フロントエンド
- `omikuji.vue`: `no_entropy` → 新state `empty`(お告げ風メッセージ+再確認ボタン)
- `OmikujiResult.vue`: 物理乱数で引いた結果の短冊下部に「⚛️ この御籤は量子ゆらぎと放射性崩壊(物理乱数)が決めました」+バッチラベルを表示(導入前の保存結果は非表示)

### 配信・デプロイ
- dev/prod の omikujiGo に `KUDA_BASE_URL=https://kuda.kojiran.workers.dev` を追加

## 検証

- ユニット: `bytesToUnitFloat` / `byteToUnitFloat` / `dedupBatches` / 境界値→tier写像
- 統合(モックkuda+Firestoreエミュレータ、実プールは消費しない):
  - 正常抽選 → 3バイト消費・entropy付きsuccess・omikuji_logsにbatch記録 ✅
  - 枯渇(503)→ no_entropy・**last_omikuji未書き込み**・復旧後にsuccess ✅
  - 接続不能 → error ✅ / peekはkuda非呼び出し ✅
- `yarn generate` 成功、ヘッドレスで出自フッター・枯渇画面の描画確認
- 実kudaへの疎通はdevデプロイ後に確認(セッションのプロキシからは直接届かないため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_