### PR TITLE
UIの絵文字をFontAwesome単色アイコンに置き換え

### DIFF
--- a/web/components/GithubStats.vue
+++ b/web/components/GithubStats.vue
@@ -29,7 +29,7 @@
           </div>
         </div>
         <div class="tile">
-          <div class="tile-value">⭐ {{ stats.stars_total.toLocaleString() }}</div>
+          <div class="tile-value"><i class="fas fa-star"></i> {{ stats.stars_total.toLocaleString() }}</div>
           <div class="tile-label">獲得スター</div>
         </div>
         <div class="tile">
@@ -66,14 +66,14 @@
       <template v-if="stats.top_repos.length > 0 || editable">
         <div class="d-flex align-items-center mt-3 mb-1">
           <div class="gh-sub">
-            {{ stats.top_repos_source === "pinned" ? "📌 ピン留めリポジトリ" : "代表リポジトリ" }}
+            {{ stats.top_repos_source === "pinned" ? "ピン留めリポジトリ" : "代表リポジトリ" }}
           </div>
           <button
             v-if="editable && !pickerOpen"
             class="btn btn-sm btn-outline-light ms-2 pick-btn"
             @click="pickerOpen = true"
           >
-            📌 選ぶ
+            <i class="fas fa-fw fa-thumbtack"></i> 選ぶ
           </button>
         </div>
         <RepoPicker
@@ -103,8 +103,8 @@
                 <span class="lang-dot" :style="{ background: langColor(r.language) }"></span>
                 {{ r.language }}
               </span>
-              <span class="me-3">⭐ {{ r.stars.toLocaleString() }}</span>
-              <span v-if="r.forks > 0">🍴 {{ r.forks.toLocaleString() }}</span>
+              <span class="me-3"><i class="fas fa-star"></i> {{ r.stars.toLocaleString() }}</span>
+              <span v-if="r.forks > 0"><i class="fas fa-code-branch"></i> {{ r.forks.toLocaleString() }}</span>
             </div>
           </a>
         </div>

--- a/web/components/OmikujiResult.vue
+++ b/web/components/OmikujiResult.vue
@@ -17,7 +17,7 @@
 
       <!-- 物理乱数の出自(kudaで引いたときだけ表示) -->
       <div v-if="isPhysical" class="entropy">
-        <div>⚛️ この御籤は量子ゆらぎと放射性崩壊(物理乱数)が決めました</div>
+        <div><i class="fas fa-atom"></i> この御籤は量子ゆらぎと放射性崩壊(物理乱数)が決めました</div>
         <div class="entropy-batches">
           <span v-for="b in result.entropy.batches" :key="b" class="entropy-batch">{{
             b

--- a/web/components/ProfileStats.vue
+++ b/web/components/ProfileStats.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="profile-stats p-3 rounded">
     <div class="d-flex justify-content-between align-items-center flex-wrap mb-2">
-      <h2 class="stats-title fs-6 mb-0">📊 参拝の記録</h2>
+      <h2 class="stats-title fs-6 mb-0"><i class="fas fa-fw fa-chart-bar"></i> 参拝の記録</h2>
     </div>
 
     <div v-if="state === 'loading'" class="stats-sub py-3">
@@ -24,7 +24,7 @@
           <div class="tile-value">
             {{ stats.sanpai.current_streak
             }}<span class="tile-unit">日</span>
-            <span v-if="stats.sanpai.current_streak >= 3">🔥</span>
+            <span v-if="stats.sanpai.current_streak >= 3"><i class="fas fa-fire streak-fire"></i></span>
           </div>
           <div class="tile-label">連続参拝中</div>
         </div>
@@ -125,6 +125,11 @@ export default {
 </script>
 
 <style scoped>
+/* ストリーク継続中の炎(元の🔥に合わせて琥珀で彩色) */
+.streak-fire {
+  color: var(--color-accent);
+}
+
 .profile-stats {
   background: var(--color-surface);
   border: 1px solid rgba(255, 255, 255, 0.08);

--- a/web/components/RepoPicker.vue
+++ b/web/components/RepoPicker.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="repo-picker rounded p-3">
     <div class="d-flex justify-content-between align-items-center mb-2">
-      <div class="picker-title">📌 表示するリポジトリを選ぶ</div>
+      <div class="picker-title"><i class="fas fa-fw fa-thumbtack"></i> 表示するリポジトリを選ぶ</div>
       <button class="btn btn-sm btn-outline-light" @click="$emit('close')">
         閉じる
       </button>
@@ -47,7 +47,7 @@
             {{ repo.name }}
             <span v-if="repo.fork" class="picker-sub">(fork)</span>
           </span>
-          <span class="picker-sub">⭐ {{ repo.stars }}</span>
+          <span class="picker-sub"><i class="fas fa-star"></i> {{ repo.stars }}</span>
         </label>
         <div v-if="filteredCandidates.length === 0" class="picker-sub p-2">
           該当するリポジトリがありません。

--- a/web/components/SanpaiGrass.vue
+++ b/web/components/SanpaiGrass.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="sanpai-grass p-3 rounded">
     <div class="d-flex justify-content-between align-items-center flex-wrap mb-2">
-      <h2 class="grass-title fs-6 mb-0">⛩️ 参拝の草</h2>
+      <h2 class="grass-title fs-6 mb-0"><i class="fas fa-fw fa-seedling"></i> 参拝の草</h2>
       <div v-if="state === 'loaded'" class="grass-sub">
         直近1年: {{ recent.totalCount }}回参拝
       </div>
@@ -36,7 +36,7 @@
           class="btn btn-sm btn-outline-light"
           @click="loadAll"
         >
-          📜 全期間を解析する
+          <i class="fas fa-fw fa-scroll"></i> 全期間を解析する
         </button>
         <div v-else-if="allState === 'loading'" class="grass-sub py-2">
           全期間の参拝を解析しています<span class="dots"></span>

--- a/web/pages/dashboard/index.vue
+++ b/web/pages/dashboard/index.vue
@@ -120,7 +120,7 @@
       />
       <!-- README埋め込みバッジ(自分のプロフィールへの導線をGitHubに貼れる) -->
       <div v-if="user && user.screen_name" class="badge-section p-3 rounded mt-4">
-        <div class="fw-bold mb-2">🔖 READMEに貼れるバッジ</div>
+        <div class="fw-bold mb-2"><i class="fas fa-fw fa-bookmark"></i> READMEに貼れるバッジ</div>
         <p class="badge-note mb-2">
           GitHubのプロフィールREADMEに貼ると、レベルと戦闘力のバッジから
           公開プロフィールへ飛べます。

--- a/web/pages/index.vue
+++ b/web/pages/index.vue
@@ -71,7 +71,7 @@
       <div class="container py-4 mt-4">
         <div class="row flex-row-reverse">
           <div class="col-12 col-md-6 col-lg-4 px-4">
-            <h2 class="section-title mb-3">🏆 ランキング</h2>
+            <h2 class="section-title mb-3"><i class="fas fa-fw fa-trophy"></i> ランキング</h2>
             <ranking max="10" class="mt-3"></ranking>
             <div class="text-end px-4 mt-3 mb-4">
               <nuxt-link to="/ranking">
@@ -80,7 +80,7 @@
             </div>
           </div>
           <div class="col-12 col-md-6 col-lg-8 px-4 mb-4">
-            <h2 class="section-title mb-3">⛩️ でばっぐ神社とは</h2>
+            <h2 class="section-title mb-3"><i class="fas fa-fw fa-torii-gate"></i> でばっぐ神社とは</h2>
             <p class="fs-4">
               <span class="text-danger"
                 ><strong>露御読把和流（ろおどはわる）</strong></span
@@ -97,7 +97,7 @@
                 >もっと詳しく <i class="fas fa-fw fa-chevron-right"></i
               ></nuxt-link>
             </div>
-            <h2 class="section-title mt-5 mb-3">💬 開発コミュニティ</h2>
+            <h2 class="section-title mt-5 mb-3"><i class="fas fa-fw fa-comments"></i> 開発コミュニティ</h2>
             <div class="">
               <a href="https://discord.gg/HTdSVdgEXJ" target="_blank" class="btn btn-lg bg-discord text-white mt-2 me-2">
                 <i class="fab fa-discord fa-fw fa-lg"></i> 四谷ラボ Discord
@@ -106,7 +106,7 @@
                 <i class="fab fa-github fa-fw fa-lg"></i> 四谷ラボ GitHub
               </a>
             </div>
-            <h2 class="section-title mt-5 mb-3">📦 でばっぐ神社リポジトリ</h2>
+            <h2 class="section-title mt-5 mb-3"><i class="fas fa-fw fa-box"></i> でばっぐ神社リポジトリ</h2>
             <div class="mt-2">
               <a href="https://github.com/428lab/debug-shrine" target="_blank">
                 <i class="fab fa-github fa-fw fa-lg"></i> 428lab/debug-shrine

--- a/web/pages/omikuji.vue
+++ b/web/pages/omikuji.vue
@@ -18,7 +18,7 @@
 
     <!-- 引ける -->
     <div v-else-if="state === 'available'" class="my-5">
-      <div class="omikuji-box mx-auto mb-4">⛩️</div>
+      <div class="omikuji-box mx-auto mb-4"><i class="fas fa-torii-gate"></i></div>
       <button class="btn btn-lg btn-accent px-5" @click="startScene">
         おみくじを引く
       </button>
@@ -59,7 +59,7 @@
 
     <!-- 物理乱数(kuda)が枯渇・停止中。疑似乱数では引かない -->
     <div v-else-if="state === 'empty'" class="my-5">
-      <div class="fs-1">⚛️</div>
+      <div class="fs-1"><i class="fas fa-atom"></i></div>
       <div class="fs-4 mt-3">
         「御籤の源(物理乱数)が尽きておる…<br class="d-md-none" />しばし待たれよ。」
       </div>
@@ -273,6 +273,7 @@ export default {
   height: 120px;
   line-height: 120px;
   font-size: 64px;
+  color: var(--color-accent);
   border-radius: 12px;
   background: radial-gradient(circle at 50% 40%, #5a5050, #2b2b2b 70%);
   box-shadow: 0 0 18px rgba(255, 180, 90, 0.4);


### PR DESCRIPTION
## 概要

#183 の第1弾。機種依存の見た目を排除するため、フロントUIの絵文字をFontAwesome単色アイコン(文字色追従)に置き換えます。DESIGN.md の方針(絵文字は使わない・例外はユーザー投稿テンプレの⛩のみ)に沿った対応です。

## 置き換え内容

| 箇所 | 置き換え |
|---|---|
| 見出し「🏆 ランキング」(index) | `fa-trophy` |
| 見出し「⛩️ でばっぐ神社とは」(index) | `fa-torii-gate` |
| 見出し「💬 開発コミュニティ」(index) | `fa-comments` |
| 見出し「📦 でばっぐ神社リポジトリ」(index) | `fa-box` |
| 見出し「📊 参拝の記録」(ProfileStats) | `fa-chart-bar` |
| 見出し「⛩️ 参拝の草」(SanpaiGrass) | `fa-seedling` |
| 「📜 全期間を解析する」ボタン | `fa-scroll` |
| 📌(RepoPicker/GithubStatsのラベル・ボタン) | `fa-thumbtack`(ラベル側は文言のみに) |
| ⭐ スター数(3箇所) | `fa-star` |
| 🍴 フォーク数 | `fa-code-branch` |
| 「🔖 READMEに貼れるバッジ」(dashboard) | `fa-bookmark` |
| 🔥 ストリーク継続 | `fa-fire`(琥珀で彩色) |
| ⚛️ 物理乱数の表記(結果カード・枯渇画面) | `fa-atom` |
| ⛩️ おみくじ筐体 | `fa-torii-gate`(琥珀で彩色) |

## 対象外(#183で継続)

- ユーザー投稿テンプレ(参拝・おみくじ共有文言)の ⛩ — **例外として維持**
- おみくじtier絵文字(🌟🎉😊等: 結果カード・共有文言・ダッシュボード) — 表現の要なので別途検討
- 称号バッジの絵文字17種 — バックエンド(profileStatsGo)由来のためAPI側の設計変更が必要
- 二拍手の👏🏻 — 参拝の儀式表現の要なので別途検討

`yarn generate` 成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_