### PR TITLE
デプロイの409(operation未解放)に1回リトライを追加

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -242,15 +242,27 @@ jobs:
             local name="$1"; shift
             local entry="$1"; shift
             echo "start deploy: $name"
-            ( gcloud functions deploy "$name" \
-                --project=d-shrine-dev \
-                --gen2 \
-                --runtime=go125 \
-                --region=us-central1 \
-                --docker-repository="$DOCKER_REPO" \
-                --source=. \
-                --entry-point="$entry" \
-                "$@" ) > "/tmp/deploy-$name.log" 2>&1 &
+            # 直前のデプロイrunのGCP側オペレーションが未解放だと 409
+            # (unable to queue the operation)で即失敗するため、90秒おいて
+            # 1回だけリトライする(マージが近接して連続デプロイになった場合の対策)。
+            ( for attempt in 1 2; do
+                if gcloud functions deploy "$name" \
+                    --project=d-shrine-dev \
+                    --gen2 \
+                    --runtime=go125 \
+                    --region=us-central1 \
+                    --docker-repository="$DOCKER_REPO" \
+                    --source=. \
+                    --entry-point="$entry" \
+                    "$@"; then
+                  exit 0
+                fi
+                if [ "$attempt" -eq 1 ]; then
+                  echo "deploy $name failed (attempt 1); retrying in 90s..."
+                  sleep 90
+                fi
+              done
+              exit 1 ) > "/tmp/deploy-$name.log" 2>&1 &
             PIDS+=("$!")
             NAMES+=("$name")
           }

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -190,15 +190,27 @@ jobs:
             local name="$1"; shift
             local entry="$1"; shift
             echo "start deploy: $name"
-            ( gcloud functions deploy "$name" \
-                --project=d-shrine \
-                --gen2 \
-                --runtime=go125 \
-                --region=us-central1 \
-                --docker-repository="$DOCKER_REPO" \
-                --source=. \
-                --entry-point="$entry" \
-                "$@" ) > "/tmp/deploy-$name.log" 2>&1 &
+            # 直前のデプロイrunのGCP側オペレーションが未解放だと 409
+            # (unable to queue the operation)で即失敗するため、90秒おいて
+            # 1回だけリトライする(マージが近接して連続デプロイになった場合の対策)。
+            ( for attempt in 1 2; do
+                if gcloud functions deploy "$name" \
+                    --project=d-shrine \
+                    --gen2 \
+                    --runtime=go125 \
+                    --region=us-central1 \
+                    --docker-repository="$DOCKER_REPO" \
+                    --source=. \
+                    --entry-point="$entry" \
+                    "$@"; then
+                  exit 0
+                fi
+                if [ "$attempt" -eq 1 ]; then
+                  echo "deploy $name failed (attempt 1); retrying in 90s..."
+                  sleep 90
+                fi
+              done
+              exit 1 ) > "/tmp/deploy-$name.log" 2>&1 &
             PIDS+=("$!")
             NAMES+=("$name")
           }


### PR DESCRIPTION
## 概要

マージが近接して連続デプロイになると、前のrunのGCP側オペレーションが未解放の関数が `409 unable to queue the operation` で即失敗する(#178のdevデプロイ run 29461737836 で実際に発生し、rerun_failed_jobs で復旧した)。

dev-deploy.yml / prod-deploy.yml の `deploy()` ヘルパーで、`gcloud functions deploy` が失敗した場合に **90秒待って1回だけリトライ**するようにする。並列デプロイの構造(バックグラウンド起動+PID収集+wait)はそのまま。

## 検証

- 両YAMLの構文チェック(python yaml.safe_load)OK
- 差分が deploy() のリトライループのみであることを確認
- マージ後の env/dev / env/prod への昇格デプロイ自体が新しい deploy() の動作確認になる(リトライの実発動は次に409が起きた際のログ「retrying in 90s...」で確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_