### PR TITLE
狐がひと跳びで本命に直行する演出(約20%)を追加

### DIFF
--- a/web/components/OmikujiScene.vue
+++ b/web/components/OmikujiScene.vue
@@ -327,9 +327,11 @@ export default {
       const target = this.targetBinIndex >= 0 ? this.targetBinIndex : 0;
       this.hopSeq = foxHopSequence(target, GEO.BIN_COUNT);
       this.hopIndex = 0;
-      // まず寝床からひと跳びで最初のビンへ
-      this.doHop(this.foxLeft, this.binLeftPct(this.hopSeq[0]), FOX.binBottom, false, () => {
-        this.later(500, () => this.nextHop());
+      // まず寝床からひと跳びで最初のビンへ。ひと跳び直行(hopSeqが本命のみ)の
+      // 場合はこれが決めのジャンプなので、本命着地の演出(長い溜め・長い滞空)にする。
+      const directToTarget = this.hopSeq.length === 1;
+      this.doHop(this.foxLeft, this.binLeftPct(this.hopSeq[0]), FOX.binBottom, directToTarget, () => {
+        this.later(directToTarget ? 250 : 500, () => this.nextHop());
       });
     },
     nextHop() {

--- a/web/components/omikujiFox.js
+++ b/web/components/omikujiFox.js
@@ -7,13 +7,24 @@
 // この関数は演出用だが、「最後のホップ先 == targetBin」「途中はターゲット以外」という
 // 公平性の核を Node で決定論的に検証できるよう純粋に保つ(乱数は引数で注入可能)。
 
+// ひと跳び直行(おとり無し)の確率。毎回2〜3回のフェイクアウトだと展開が
+// 読めてしまうため、たまに迷いなく本命へ飛び込むパターンを混ぜる。
+const DIRECT_HOP_RATE = 0.2;
+
 // targetBin: 本命の物理ビン index(0..binCount-1)
 // binCount : ビン数(通常7)
 // rnd      : 0..1 の乱数関数(省略時 Math.random)。テストでは固定値を注入する。
-// 返り値   : ビン index の配列。末尾が必ず targetBin。長さ >= 2(おとり>=1 + 本命)。
+// 返り値   : ビン index の配列。末尾が必ず targetBin。
+//            約20%で [targetBin] のみ(ひと跳び直行)、それ以外は
+//            おとり2〜3 + 本命(長さ3〜4)。
 function foxHopSequence(targetBin, binCount, rnd) {
   rnd = rnd || Math.random;
   if (binCount <= 1) return [targetBin];
+
+  // ひと跳び直行: おとり無しで寝床から本命へ飛び込む。
+  if (rnd() < DIRECT_HOP_RATE) {
+    return [targetBin];
+  }
 
   // おとりの回数(2〜3)。1ホップに溜め・着地・間を含めて約2秒かけるため、
   // 多すぎると尺が延びる。ビンが少なければさらに抑える。
@@ -43,4 +54,4 @@ function foxHopSequence(targetBin, binCount, rnd) {
   return seq;
 }
 
-module.exports = { foxHopSequence };
+module.exports = { foxHopSequence, DIRECT_HOP_RATE };


### PR DESCRIPTION
## 概要

おみくじ演出の狐は現在、必ずダミービンを2〜3回経由してから本命に着地します(3〜4ジャンプ)。展開が読めてしまうため、**約20%の確率でおとり無しに寝床から本命ビンへひと跳びで直行**するパターンを追加します。

## 変更

- `omikujiFox.js` の `foxHopSequence`: 冒頭で `rnd() < DIRECT_HOP_RATE(0.2)` なら `[targetBin]`(長さ1)を返す。rnd注入可能な純関数の設計は維持
- `OmikujiScene.vue` の `startHops`: ひと跳び直行時は最初のジャンプに本命着地の演出(溜め780ms・滞空950ms)を適用。着地後は既存の終端処理(happyポーズ+ビン発光+1秒→結果表示)がそのまま働く

抽選結果(tier)はサーバー(kuda物理乱数)決定のままで、**演出のみ**の変更です(演出用Math.randomは既存の使用実績あり)。狐は targetTier がサーバーから届くまで跳ばない既存ゲートを通るため、ジャンプ短縮によるレースはありません。

## 検証

- Nodeヘッドレス検証: 10万回実行で直行率 20.05%、長さ分布 {1: 20052, 3: 40195, 4: 39753}、不変条件(直行時は`[target]`のみ / 非直行時は末尾=本命・おとりは本命/直前と重複なし)違反ゼロ
- rnd注入の決定的テスト: rnd=0.19→`[3]`、rnd=0.20→`[0,6,3]`
- `yarn generate` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_