### PR TITLE
狐ホップにその場ジャンプと本命ティーズルートを追加

### DIFF
--- a/web/components/omikujiFox.js
+++ b/web/components/omikujiFox.js
@@ -4,19 +4,31 @@
 // うち tier が載っている物理ビン(= targetBin)へ狐が最後に着地することで結果を"選ぶ"。
 // 途中はおとり(フェイクアウト)で別のビンに跳ねてハラハラさせる。
 //
-// この関数は演出用だが、「最後のホップ先 == targetBin」「途中はターゲット以外」という
-// 公平性の核を Node で決定論的に検証できるよう純粋に保つ(乱数は引数で注入可能)。
+// この関数は演出用だが、「最後のホップ先 == targetBin」という公平性の核を
+// Node で決定論的に検証できるよう純粋に保つ(乱数は引数で注入可能)。
 
 // ひと跳び直行(おとり無し)の確率。毎回2〜3回のフェイクアウトだと展開が
 // 読めてしまうため、たまに迷いなく本命へ飛び込むパターンを混ぜる。
 const DIRECT_HOP_RATE = 0.2;
 
+// 本命ティーズの確率(非直行時)。一度本命ビンに入ってから別のビンへ離れ、
+// 最後にやっぱり本命へ戻ってくるルート(この時点ではビンは光らないので
+// 見ている側は「そこ!?…違うんかい…やっぱりそこか!」となる)。
+const TARGET_TEASE_RATE = 0.3;
+
+// おとり各スロット(2番目以降)が「その場ジャンプ」(直前と同じビンに
+// 跳ね直す)になる確率。
+const STAY_HOP_RATE = 0.2;
+
 // targetBin: 本命の物理ビン index(0..binCount-1)
 // binCount : ビン数(通常7)
 // rnd      : 0..1 の乱数関数(省略時 Math.random)。テストでは固定値を注入する。
 // 返り値   : ビン index の配列。末尾が必ず targetBin。
-//            約20%で [targetBin] のみ(ひと跳び直行)、それ以外は
-//            おとり2〜3 + 本命(長さ3〜4)。
+//            - 約20%: [targetBin] のみ(ひと跳び直行)
+//            - 残りの約30%: 本命ティーズ [targetBin, d1, (d2), targetBin]
+//            - それ以外: おとり2〜3 + 本命(長さ3〜4)
+//            おとりにはその場ジャンプ(直前と同じビン)が混ざり得るが、
+//            末尾直前は必ず本命以外(フィナーレは移動して本命着地)。
 function foxHopSequence(targetBin, binCount, rnd) {
   rnd = rnd || Math.random;
   if (binCount <= 1) return [targetBin];
@@ -26,8 +38,27 @@ function foxHopSequence(targetBin, binCount, rnd) {
     return [targetBin];
   }
 
-  // おとりの回数(2〜3)。1ホップに溜め・着地・間を含めて約2秒かけるため、
-  // 多すぎると尺が延びる。ビンが少なければさらに抑える。
+  // 本命ティーズ: 先頭で本命に入り、1〜2ビン離れてから本命へ戻る。
+  if (rnd() < TARGET_TEASE_RATE) {
+    const mids = 1 + Math.floor(rnd() * 2); // 1 or 2
+    const seq = [targetBin];
+    let prev = targetBin;
+    for (let i = 0; i < mids; i++) {
+      // 2番目以降はその場ジャンプ可(先頭は本命から離れる必要があるので不可)。
+      if (i > 0 && prev !== targetBin && rnd() < STAY_HOP_RATE) {
+        seq.push(prev);
+        continue;
+      }
+      const b = pickOtherBin(targetBin, prev, binCount, rnd);
+      seq.push(b);
+      prev = b;
+    }
+    seq.push(targetBin); // やっぱり本命へ戻って締める
+    return seq;
+  }
+
+  // 通常ルート: おとりの回数(2〜3)。1ホップに溜め・着地・間を含めて約2秒
+  // かけるため、多すぎると尺が延びる。ビンが少なければさらに抑える。
   const maxDecoys = Math.min(3, binCount - 1);
   const minDecoys = Math.min(2, maxDecoys);
   const decoys = minDecoys + Math.floor(rnd() * (maxDecoys - minDecoys + 1));
@@ -35,18 +66,12 @@ function foxHopSequence(targetBin, binCount, rnd) {
   const seq = [];
   let prev = -1;
   for (let i = 0; i < decoys; i++) {
-    let b;
-    let guard = 0;
-    // ターゲット以外・直前と違うビン(跳ね回る感)を選ぶ。
-    do {
-      b = Math.floor(rnd() * binCount);
-      if (b >= binCount) b = binCount - 1;
-      guard++;
-    } while ((b === targetBin || b === prev) && guard < 30);
-    // ガードで抜けても不正値にならないよう最終フォールバック。
-    if (b === targetBin) {
-      b = (targetBin + 1) % binCount;
+    // 2番目以降のおとりはその場ジャンプ可(先頭は寝床からの移動なので不可)。
+    if (i > 0 && rnd() < STAY_HOP_RATE) {
+      seq.push(prev);
+      continue;
     }
+    const b = pickOtherBin(targetBin, prev, binCount, rnd);
     seq.push(b);
     prev = b;
   }
@@ -54,4 +79,25 @@ function foxHopSequence(targetBin, binCount, rnd) {
   return seq;
 }
 
-module.exports = { foxHopSequence, DIRECT_HOP_RATE };
+// ターゲット以外・直前と違うビン(跳ね回る感)を1つ選ぶ。
+// ガードで抜けても不正値にならないよう最終フォールバック付き。
+function pickOtherBin(targetBin, prev, binCount, rnd) {
+  let b;
+  let guard = 0;
+  do {
+    b = Math.floor(rnd() * binCount);
+    if (b >= binCount) b = binCount - 1;
+    guard++;
+  } while ((b === targetBin || b === prev) && guard < 30);
+  if (b === targetBin) {
+    b = (targetBin + 1) % binCount;
+  }
+  return b;
+}
+
+module.exports = {
+  foxHopSequence,
+  DIRECT_HOP_RATE,
+  TARGET_TEASE_RATE,
+  STAY_HOP_RATE,
+};


### PR DESCRIPTION
## 概要

#187(ひと跳び直行20%)に続く狐ルートのバリエーション追加です。

- **本命ティーズ**(非直行時の約30% = 全体の約24%): 一度本命ビンに入る → 別のビンへ離れる → 最後にやっぱり本命へ戻る `[本命, d1, (d2), 本命]`。途中着地ではビンが光らないので「そこ!?…違うんかい…やっぱりそこか!」の演出になる
- **その場ジャンプ**(おとり各スロットの約20%): 直前と同じビンに垂直に跳ね直す(`doHop` は from===to でも頂点15pxの垂直ジャンプとして動くためScene側は変更なし)

## 不変条件(維持)

- 末尾は必ず本命ビン
- 末尾の直前は本命以外(フィナーレは必ず「移動して本命着地」)
- 長さは 1(直行)/ 3〜4

## 検証

- Nodeヘッドレス10万回: 直行20.10% / ティーズ24.2% / その場ジャンプ入り18.1%、不変条件違反ゼロ
- rnd注入の決定的テストで4ルート(直行・ティーズ1/2・STAY)を再現
- `yarn generate` 成功

抽選結果はサーバー(kuda物理乱数)決定のままで、演出のみの変更です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_