### PR TITLE
狐の居座り決定パターン(約10%)を追加

### DIFF
--- a/web/components/omikujiFox.js
+++ b/web/components/omikujiFox.js
@@ -11,8 +11,13 @@
 // 読めてしまうため、たまに迷いなく本命へ飛び込むパターンを混ぜる。
 const DIRECT_HOP_RATE = 0.2;
 
-// 本命ティーズの確率(非直行時)。一度本命ビンに入ってから別のビンへ離れ、
-// 最後にやっぱり本命へ戻ってくるルート(この時点ではビンは光らないので
+// 居座り決定の確率(非直行時 0.125 = 全体の約10%)。本命ビンに入った狐が
+// 移動せず、その場で長い溜めから垂直ジャンプして着地と同時に確定する
+// (「え、動かないの?…そこでいいんかい!」という演出)。
+const STAY_DECIDE_RATE = 0.125;
+
+// 本命ティーズの確率(非直行・非居座り時)。一度本命ビンに入ってから別のビンへ
+// 離れ、最後にやっぱり本命へ戻ってくるルート(この時点ではビンは光らないので
 // 見ている側は「そこ!?…違うんかい…やっぱりそこか!」となる)。
 const TARGET_TEASE_RATE = 0.3;
 
@@ -25,10 +30,11 @@ const STAY_HOP_RATE = 0.2;
 // rnd      : 0..1 の乱数関数(省略時 Math.random)。テストでは固定値を注入する。
 // 返り値   : ビン index の配列。末尾が必ず targetBin。
 //            - 約20%: [targetBin] のみ(ひと跳び直行)
+//            - 約10%: [targetBin, targetBin](居座り決定=最後は垂直ジャンプ)
 //            - 残りの約30%: 本命ティーズ [targetBin, d1, (d2), targetBin]
 //            - それ以外: おとり2〜3 + 本命(長さ3〜4)
 //            おとりにはその場ジャンプ(直前と同じビン)が混ざり得るが、
-//            末尾直前は必ず本命以外(フィナーレは移動して本命着地)。
+//            居座り決定を除き末尾直前は本命以外(フィナーレは移動して本命着地)。
 function foxHopSequence(targetBin, binCount, rnd) {
   rnd = rnd || Math.random;
   if (binCount <= 1) return [targetBin];
@@ -36,6 +42,13 @@ function foxHopSequence(targetBin, binCount, rnd) {
   // ひと跳び直行: おとり無しで寝床から本命へ飛び込む。
   if (rnd() < DIRECT_HOP_RATE) {
     return [targetBin];
+  }
+
+  // 居座り決定: 本命に入って動かず、その場の垂直ジャンプで確定する。
+  // Scene側は [本命, 本命] を受けると「移動して入る(光らない)→
+  // isFinalの長い溜め→垂直ジャンプ→着地で発光」になる(コード変更不要)。
+  if (rnd() < STAY_DECIDE_RATE) {
+    return [targetBin, targetBin];
   }
 
   // 本命ティーズ: 先頭で本命に入り、1〜2ビン離れてから本命へ戻る。
@@ -98,6 +111,7 @@ function pickOtherBin(targetBin, prev, binCount, rnd) {
 module.exports = {
   foxHopSequence,
   DIRECT_HOP_RATE,
+  STAY_DECIDE_RATE,
   TARGET_TEASE_RATE,
   STAY_HOP_RATE,
 };


### PR DESCRIPTION
## 概要

#187/#188 に続く狐ルートの追加。**本命ビンに入った狐が移動せず、その場の垂直ジャンプで確定する「居座り決定」**を約10%で発生させます(「え、動かないの?…そこでいいんかい!」)。

## 実装

`foxHopSequence` が `[本命, 本命]` を返すだけ。Scene側は既存実装のまま:
1. 移動して本命に入る(この時点では光らない)
2. 最後のホップが isFinal になるので**長い溜め(780ms)→ 垂直ジャンプ(950ms・頂点15px)**
3. 着地でhappyポーズ+ビン発光→結果表示

## ルート配分(全体比)

| ルート | 確率 |
|---|---|
| ひと跳び直行 `[t]` | 20% |
| **居座り決定 `[t,t]`** | **10%** |
| 本命ティーズ `[t,d,(d),t]` | 約21% |
| 従来(おとり2〜3+本命、その場ジャンプ混在) | 約49% |

## 検証

- Node 10万回: 直行19.97% / 居座り9.92% / ティーズ21.05%、不変条件違反ゼロ(長さ2は必ず`[t,t]`、それ以外は末尾直前≠本命)
- rnd注入で `[3,3]` を決定的に再現
- `yarn generate` 成功

抽選結果はサーバー(kuda物理乱数)決定のままで、演出のみの変更です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_