### PR TITLE
おみくじ演出のタップスキップをiOSでも効くように修正

### DIFF
--- a/web/components/OmikujiScene.vue
+++ b/web/components/OmikujiScene.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="omikuji-scene" @click="onTap">
+  <!-- スキップはclickとtouchendの両方で拾う。装置canvasのMatter.Mouseが
+       touchstartをpreventDefaultするため、iOS Safariではcanvas上のタップで
+       clickが合成されない(touchendはバブルするので拾える)。 -->
+  <div class="omikuji-scene" @click="onTap" @touchend="onTap">
     <div ref="inner" class="scene-inner" :style="innerStyle">
       <!-- からくり装置(鈴の緒・絵馬・水車・斜面)の物理キャンバス -->
       <div v-if="!reducedMotion" ref="canvasWrap" class="canvas-wrap"></div>


### PR DESCRIPTION
## 原因

からくり装置のcanvasに `Matter.Mouse.create(canvas)` が `touchstart`/`touchmove` リスナーを張り `preventDefault()` を呼ぶため、**iOS Safariでは touchstart が preventDefault されると click イベントが合成されない**。canvasは画面全体を覆っているので、ルートの `@click="onTap"` がiPhoneのタップでは一切発火しなかった(PCはマウスイベント経由なので動く)。

## 修正

`preventDefault` はバブリングは止めないため、ルートで `@touchend="onTap"` も拾うようにする(1行)。

- `finish()` は `phase === "done"` ガード済みなので、click と touchend の二重発火は無害
- 儀式中(鈴の緒ドラッグ)の touchend は従来どおり `onTap` 内の phase 判定で無視される
- 鈴の緒フォールバックリンク等はヒントレイヤー上(canvas外)なので従来どおり click が動く

`yarn generate` 成功。実機確認はdevで(iPhoneで演出中にタップ→スキップ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_