### PR TITLE
玉2が斜面Cの途中で失速するのを修正

### DIFF
--- a/web/components/omikujiMachine.js
+++ b/web/components/omikujiMachine.js
@@ -67,7 +67,14 @@ const GEO = {
   // 静止中の玉2はジッターで動かず、天辺のドミノに押されて目覚めた時だけ
   // 左端から壁沿いの溝へ転がり落ちる。
   RELAY_PERCH: { x: 38, y: 521, w: 24, h: 10, angle: 0 },
-  BALL2: { x: 30, y: 505 },
+  // friction はあえて玉1(0.01)より低くする。0.01だと緩い斜面Cの途中で
+  // 摩擦がスピンをかけ「滑り→転がり」に転換した瞬間、並進速度が回転に
+  // 食われて速度2.5→0.8に急失速し、以降4秒近くノロノロ進んでテンポが
+  // 悪かった(グリップ地点は決定論なので毎回同じ場所で失速する)。
+  // 0.001ならグリップが斜面の終端より先に来ず、加速したまま狐へ届く
+  // (0だと台の上でジッターを保持できず眠れなくなり、ドミノを待たずに
+  // 滑り落ちてリレーが崩壊するためNG。Node実測: 鈴→狐 12.2s → 6.9s)。
+  BALL2: { x: 30, y: 505, friction: 0.001 },
 
   // 玉1の受け皿。最下段のドミノを倒し終えた玉1をキャッチして舞台に残す
   // (玉1が下へ抜けて先に狐へ届いてしまうとリレーの意味が無くなる)。
@@ -235,7 +242,7 @@ function buildMachineWorld(Matter) {
   const relayBall = Bodies.circle(GEO.BALL2.x, GEO.BALL2.y, GEO.BALL.r, {
     density: GEO.BALL.density,
     restitution: GEO.BALL.restitution,
-    friction: GEO.BALL.friction,
+    friction: GEO.BALL2.friction,
     frictionAir: GEO.BALL.frictionAir,
     label: "ball",
     render: { fillStyle: "#f2c14e" },


### PR DESCRIPTION
## 原因(Nodeシミュレーションで実測)

玉2は斜面Cに速度3.4で入るが、**摩擦がスピンをかけて「滑り→転がり」に転換する瞬間(x≈260、毎回同じ場所)、並進速度が回転に食われて 2.5 → 0.8 に急失速**。以降は緩い5.7°の坂では転がりの再加速がほぼ効かず、約4秒ノロノロ進んでいた。

tick単位ログ: x≈258まで回転ゼロで滑走 → x≈258〜272 で角速度が0→0.05に急増しつつ vx 2.3→0.9(v=ωr の転がり条件成立まで速度が食われる)。

## 修正

玉2の `friction` を 0.01 → **0.001** に(1定数)。グリップ地点が斜面の終端より先に来ないため、**加速したまま**(3.5→5.0)狐に届く。

- `friction: 0` は不可: 台の上でソルバーの微振動を保持できず眠れなくなり、**ドミノを待たずに勝手に滑り落ちてリレーが崩壊**する(実測で確認)
- 玉1のパラメータは変更なし(からくりの必通過チューニングに影響しない)

## 実測(鈴→狐のフル通し)

| friction | 台で睡眠 | ドミノ待ち | 鈴→狐 |
|---|---|---|---|
| 0.01(現状) | ✅ | ✅ | 12.23s |
| **0.001** | ✅ | ✅ | **6.87s** |
| 0 | ❌ | ❌(自走) | 3.93s(崩壊) |

`yarn generate` 成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_