### PR TITLE
鈴を鳴らした直後の誤スキップを防止(1.5秒の猶予)

### DIFF
--- a/web/components/OmikujiScene.vue
+++ b/web/components/OmikujiScene.vue
@@ -258,6 +258,10 @@ export default {
     onRing() {
       if (this.rung) return;
       this.rung = true;
+      // 鳴った直後はスキップを武装しない。鈴を鳴らしたジェスチャーの指離し
+      // (touchend)や勢い余った直後のタップが、cascadeに切り替わった瞬間の
+      // スキップ判定に食われて即結果表示になるのを防ぐ。
+      this._skipArmedAt = performance.now() + 1500;
       this.$emit("rang");
       this.ringPulse = true;
       this.later(900, () => (this.ringPulse = false));
@@ -394,6 +398,8 @@ export default {
     },
     onTap() {
       // 演出中はタップでスキップ(儀式中は誤爆防止のため無効。fallbackリンクを使う)
+      // 鳴った直後の猶予中(_skipArmedAt前)も無効(onRing参照)。
+      if (this._skipArmedAt && performance.now() < this._skipArmedAt) return;
       if (this.phase === "cascade" || this.phase === "fox") this.finish();
     },
 


### PR DESCRIPTION
## 原因

鈴が鳴った瞬間に phase が `cascade` に切り替わるため、**鈴を鳴らしたジェスチャーの指離し(touchend)や勢い余った直後のタップがそのままスキップ判定に食われて即結果表示**になっていた。#190 で touchend を拾うようになったことで顕在化。

## 修正

鳴ってから **1.5秒はスキップを武装しない**(`_skipArmedAt`)。玉の投入は鳴ってから300ms後なので、演出の冒頭を見逃すことなく誤爆だけ防げる。1.5秒経過後は従来どおり全画面タップでスキップ可能。

`yarn generate` 成功。実機確認はdevで(鈴を鳴らした直後に連打しても結果が飛ばないこと/少し待ってからのタップでスキップできること)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_