### PR TITLE
称号バッジの絵文字をFontAwesomeアイコンに置き換え

### DIFF
--- a/app/functions-go/profile_stats.go
+++ b/app/functions-go/profile_stats.go
@@ -39,9 +39,11 @@ type omikujiStats struct {
 }
 
 type profileBadge struct {
-	ID       string `json:"id"`
-	Label    string `json:"label"`
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	// Emoji は旧クライアント・CDNキャッシュ互換のため残す(表示は icon 優先)。
 	Emoji    string `json:"emoji"`
+	Icon     string `json:"icon"`
 	Desc     string `json:"desc"`
 	Achieved bool   `json:"achieved"`
 }
@@ -244,9 +246,13 @@ type profileFacts struct {
 }
 
 type badgeDef struct {
-	ID       string
-	Label    string
+	ID    string
+	Label string
+	// Emoji は互換用に残し、表示用アイコンは Icon(FontAwesome無料版のクラス名)。
+	// 絵文字は機種依存のため使わない方針(DESIGN.md / #183)。無料版に無い
+	// 絵文字は意訳(🏮→shoe-prints 🕯️→moon 🎋→scroll 🌩️→cloud-showers-heavy)。
 	Emoji    string
+	Icon     string
 	Desc     string
 	Achieved func(profileFacts) bool
 }
@@ -254,23 +260,23 @@ type badgeDef struct {
 // 称号の定義。達成済みかどうかに関わらず全件返し、フロントで未達成をグレー表示
 // する(コレクション欲を煽る)。条件はすべて既存の集計から導出できるものに限る。
 var badgeDefs = []badgeDef{
-	{"hatsumode", "初参拝", "⛩️", "はじめての参拝", func(f profileFacts) bool { return f.SanpaiTotal >= 1 }},
-	{"sanpai10", "常連さん", "🏮", "参拝10回", func(f profileFacts) bool { return f.SanpaiTotal >= 10 }},
-	{"sanpai50", "信徒", "🙏", "参拝50回", func(f profileFacts) bool { return f.SanpaiTotal >= 50 }},
-	{"sanpai100", "百度参り", "💯", "参拝100回", func(f profileFacts) bool { return f.SanpaiTotal >= 100 }},
-	{"sanpai365", "毎日詣で", "📅", "参拝365回", func(f profileFacts) bool { return f.SanpaiTotal >= 365 }},
-	{"sanpai1000", "千日参り", "🌟", "参拝1000回", func(f profileFacts) bool { return f.SanpaiTotal >= 1000 }},
-	{"streak3", "三日坊主克服", "🔥", "3日連続参拝", func(f profileFacts) bool { return f.LongestStreak >= 3 }},
-	{"streak7", "七日詣", "🕯️", "7日連続参拝", func(f profileFacts) bool { return f.LongestStreak >= 7 }},
-	{"streak30", "皆勤賞", "🎖️", "30日連続参拝", func(f profileFacts) bool { return f.LongestStreak >= 30 }},
-	{"streak100", "求道者", "⚡", "100日連続参拝", func(f profileFacts) bool { return f.LongestStreak >= 100 }},
-	{"lv10", "見習い神主", "🌱", "レベル10到達", func(f profileFacts) bool { return f.Level >= 10 }},
-	{"lv25", "本殿の主", "🛠️", "レベル25到達", func(f profileFacts) bool { return f.Level >= 25 }},
-	{"lv50", "生き神", "👑", "レベル50到達", func(f profileFacts) bool { return f.Level >= 50 }},
-	{"omikuji10", "おみくじ好き", "🎋", "おみくじ10回", func(f profileFacts) bool { return f.OmikujiTotal >= 10 }},
-	{"chokichi", "天に選ばれし者", "🌈", "超吉を引いた", func(f profileFacts) bool { return f.ChokichiCount >= 1 }},
-	{"daikyo", "受難の日", "💀", "大凶を引いた", func(f profileFacts) bool { return f.DaikyoCount >= 1 }},
-	{"daikyo3", "不運の帝王", "🌩️", "大凶を3回引いた", func(f profileFacts) bool { return f.DaikyoCount >= 3 }},
+	{"hatsumode", "初参拝", "⛩️", "fa-torii-gate", "はじめての参拝", func(f profileFacts) bool { return f.SanpaiTotal >= 1 }},
+	{"sanpai10", "常連さん", "🏮", "fa-shoe-prints", "参拝10回", func(f profileFacts) bool { return f.SanpaiTotal >= 10 }},
+	{"sanpai50", "信徒", "🙏", "fa-praying-hands", "参拝50回", func(f profileFacts) bool { return f.SanpaiTotal >= 50 }},
+	{"sanpai100", "百度参り", "💯", "fa-certificate", "参拝100回", func(f profileFacts) bool { return f.SanpaiTotal >= 100 }},
+	{"sanpai365", "毎日詣で", "📅", "fa-calendar-check", "参拝365回", func(f profileFacts) bool { return f.SanpaiTotal >= 365 }},
+	{"sanpai1000", "千日参り", "🌟", "fa-star", "参拝1000回", func(f profileFacts) bool { return f.SanpaiTotal >= 1000 }},
+	{"streak3", "三日坊主克服", "🔥", "fa-fire", "3日連続参拝", func(f profileFacts) bool { return f.LongestStreak >= 3 }},
+	{"streak7", "七日詣", "🕯️", "fa-moon", "7日連続参拝", func(f profileFacts) bool { return f.LongestStreak >= 7 }},
+	{"streak30", "皆勤賞", "🎖️", "fa-medal", "30日連続参拝", func(f profileFacts) bool { return f.LongestStreak >= 30 }},
+	{"streak100", "求道者", "⚡", "fa-bolt", "100日連続参拝", func(f profileFacts) bool { return f.LongestStreak >= 100 }},
+	{"lv10", "見習い神主", "🌱", "fa-seedling", "レベル10到達", func(f profileFacts) bool { return f.Level >= 10 }},
+	{"lv25", "本殿の主", "🛠️", "fa-tools", "レベル25到達", func(f profileFacts) bool { return f.Level >= 25 }},
+	{"lv50", "生き神", "👑", "fa-crown", "レベル50到達", func(f profileFacts) bool { return f.Level >= 50 }},
+	{"omikuji10", "おみくじ好き", "🎋", "fa-scroll", "おみくじ10回", func(f profileFacts) bool { return f.OmikujiTotal >= 10 }},
+	{"chokichi", "天に選ばれし者", "🌈", "fa-rainbow", "超吉を引いた", func(f profileFacts) bool { return f.ChokichiCount >= 1 }},
+	{"daikyo", "受難の日", "💀", "fa-skull", "大凶を引いた", func(f profileFacts) bool { return f.DaikyoCount >= 1 }},
+	{"daikyo3", "不運の帝王", "🌩️", "fa-cloud-showers-heavy", "大凶を3回引いた", func(f profileFacts) bool { return f.DaikyoCount >= 3 }},
 }
 
 func computeBadges(f profileFacts) []profileBadge {
@@ -280,6 +286,7 @@ func computeBadges(f profileFacts) []profileBadge {
 			ID:       def.ID,
 			Label:    def.Label,
 			Emoji:    def.Emoji,
+			Icon:     def.Icon,
 			Desc:     def.Desc,
 			Achieved: def.Achieved(f),
 		})

--- a/app/functions-go/profile_stats_test.go
+++ b/app/functions-go/profile_stats_test.go
@@ -90,3 +90,16 @@ func TestComputeBadges(t *testing.T) {
 		}
 	}
 }
+
+func TestBadges_AllHaveIcon(t *testing.T) {
+	// 絵文字は機種依存のため表示は icon(FontAwesome)優先(DESIGN.md / #183)。
+	// 定義漏れで絵文字フォールバックに落ちないよう全件にアイコンを要求する。
+	for _, def := range badgeDefs {
+		if def.Icon == "" {
+			t.Errorf("badge %s has no icon", def.ID)
+		}
+		if def.Emoji == "" {
+			t.Errorf("badge %s has no emoji fallback", def.ID)
+		}
+	}
+}

--- a/web/components/ProfileStats.vue
+++ b/web/components/ProfileStats.vue
@@ -50,7 +50,9 @@
           :class="{ locked: !b.achieved }"
           :title="b.desc + (b.achieved ? '' : '(未達成)')"
         >
-          {{ b.emoji }} {{ b.label }}
+          <i v-if="b.icon" class="fas fa-fw" :class="b.icon"></i
+          ><span v-else>{{ b.emoji }}</span>
+          {{ b.label }}
         </span>
       </div>
 


### PR DESCRIPTION
## 概要

#183 の最終対応。称号バッジ17種の絵文字を FontAwesome 単色アイコンに置き換えます(機種依存の見た目を排除)。対応表はユーザーレビュー済み。

## 実装

- **profileStatsGo**: `badgeDef` / `profileBadge` に `icon`(FAクラス名)を追加して返す。`emoji` は旧クライアント・CDNキャッシュ互換のため残す
- **ProfileStats.vue**: `icon` があればFA表示、無ければ絵文字にフォールバック
- 全称号に icon と emoji フォールバックがあることを保証するテストを追加

## 対応表(抜粋: 無料版に該当が無い4種の意訳)

- 🏮 常連さん → `fa-shoe-prints`(足繁く通う)
- 🕯️ 七日詣 → `fa-moon`(七夜)
- 🎋 おみくじ好き → `fa-scroll`(みくじ紙)
- 🌩️ 不運の帝王 → `fa-cloud-showers-heavy`

他13種は素直な対応(⛩️→torii-gate、🙏→praying-hands、💯→certificate、📅→calendar-check、🌟→star、🔥→fire、🎖️→medal、⚡→bolt、🌱→seedling、🛠️→tools、👑→crown、🌈→rainbow、💀→skull)。

## 検証

- Firestoreエミュレータで `go test ./...` 全パス(新テスト含む)
- `yarn generate` 成功
- devで見た目確認 → OK後に本番

これで #183 の残件は解消(二拍手の👏🏻は現状維持で確定済み)。マージ後、#183 をクローズ予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_