### PR TITLE
参拝完了後に儀式画面へ戻って再拍手→expireになる状態遷移を修正 (#198)

### DIFF
--- a/app/functions-go/sanpai.go
+++ b/app/functions-go/sanpai.go
@@ -318,7 +318,7 @@ func runSanpai(ctx context.Context, w http.ResponseWriter, client *firestore.Cli
 		// Node版は Firestore Timestamp の整数秒(.seconds、ナノ秒切り捨て)同士を比較するため、
 		// Go側も time.Time の丸め込みではなく Unix()(整数秒)で揃える。
 		if userData.LastSanpai.Unix()+int64(cfg.NextTime) > time.Now().Unix() {
-			writeJSON(w, http.StatusOK, map[string]interface{}{"status": "expire", "add_exp": 0})
+			writeJSON(w, http.StatusOK, map[string]interface{}{"status": "expire", "add_exp": 0, "next_time": cfg.NextTime})
 			return nil
 		}
 	}
@@ -477,6 +477,7 @@ func runSanpai(ctx context.Context, w http.ResponseWriter, client *firestore.Cli
 		"level_after":        formatted.Level,
 		"updated_repo_count": len(updatedRepos),
 		"action_count":       len(splited),
+		"next_time":          cfg.NextTime,
 	})
 	return nil
 }

--- a/web/pages/sanpai.vue
+++ b/web/pages/sanpai.vue
@@ -240,10 +240,14 @@ export default {
       this.ritual = false;
       this.result = "success";
       this.status = { ...this.status, ...saved };
+      return;
     }
+    // 儀式〜参拝完了まではSWの自動リロードを保留させる(#198)
+    this.setSwReloadBlocked(true);
   },
   beforeDestroy() {
     if (this.clapTimerId) clearTimeout(this.clapTimerId);
+    this.setSwReloadBlocked(false);
   },
   methods: {
     // 二拍手の判定。dblclick はモバイルで不安定なため click を自前でカウントする。
@@ -275,7 +279,14 @@ export default {
     onRetry() {
       this.isError = false;
       this.isLoading = true;
+      this.setSwReloadBlocked(true);
       this.doSanpai();
+    },
+    // sw-update.client.js が公開するガード。儀式〜参拝API実行中の
+    // SW自動リロードを保留する(#198)
+    setSwReloadBlocked(blocked) {
+      const guard = typeof window !== "undefined" && window.$swReloadGuard;
+      if (guard) guard.blocked = blocked;
     },
     // 拍手のフィードバック(バウンス再生+波紋リング追加)
     pop() {

--- a/web/pages/sanpai.vue
+++ b/web/pages/sanpai.vue
@@ -164,6 +164,10 @@
 <script>
 import { getAuth, onAuthStateChanged } from "firebase/auth";
 import { mapGetters } from "vuex";
+import {
+  saveSanpaiResult,
+  loadRestorableSanpaiResult,
+} from "~/utils/sanpaiSession";
 
 // 認証状態の復元は非同期のため、最初に確定したユーザーを待ち受ける
 function resolveCurrentUser(auth) {
@@ -212,6 +216,17 @@ export default {
         actionCount: 0,
       },
     };
+  },
+  mounted() {
+    // SWの自動リロード・PWA再起動・タブ退避復帰などで再マウントされた場合、
+    // クールダウン内なら儀式をやり直させず完了画面を復元する。儀式画面に
+    // 戻すと二拍手→サーバー判定でexpireの悪循環になる(#198)
+    const saved = loadRestorableSanpaiResult(Date.now());
+    if (saved) {
+      this.ritual = false;
+      this.result = "success";
+      this.status = { ...this.status, ...saved };
+    }
   },
   beforeDestroy() {
     if (this.clapTimerId) clearTimeout(this.clapTimerId);
@@ -295,6 +310,10 @@ export default {
         this.status.actionCount = d.action_count != null ? d.action_count : 0;
         this.result = d.status;
         this.isLoading = false;
+        if (d.status === "success") {
+          // クールダウン内の再マウントで完了画面を復元できるよう保存(#198)
+          saveSanpaiResult({ ...this.status }, d.next_time, Date.now());
+        }
       } else {
         this.isError = true;
         this.isLoading = false;

--- a/web/pages/sanpai.vue
+++ b/web/pages/sanpai.vue
@@ -136,8 +136,22 @@
       </div>
       </transition>
     </div>
-    <!-- 参拝前(儀式中)は共有UIや導線を出さない -->
-    <template v-if="!ritual">
+    <!-- 通信失敗(ネットワーク瞬断・サーバーエラー)。儀式はやり直させない -->
+    <div class="container py-5" v-if="isError && !ritual">
+      <div class="fs-1">「むむ、うまく声が届かなかったようじゃ。」</div>
+      <div class="fs-4 mt-4">
+        通信に失敗しました。少し待ってからもう一度お試しください。
+      </div>
+      <button
+        type="button"
+        class="btn btn-lg btn-accent mt-4"
+        @click="onRetry"
+      >
+        もう一度参拝する
+      </button>
+    </div>
+    <!-- 参拝前(儀式中)・結果未確定のうちは共有UIや導線を出さない -->
+    <template v-if="!ritual && result">
       <div class="my-5">
         <Share
           title="参拝したことをSNSで報告しよう"
@@ -257,6 +271,12 @@ export default {
         this.claps = 0; // 時間切れ:改めて2回必要
       }, 700);
     },
+    // 通信失敗後の再試行。儀式(二拍手)は済んでいるのでAPIだけやり直す
+    onRetry() {
+      this.isError = false;
+      this.isLoading = true;
+      this.doSanpai();
+    },
     // 拍手のフィードバック(バウンス再生+波紋リング追加)
     pop() {
       this.popKey += 1;
@@ -283,40 +303,45 @@ export default {
       };
       // Go版(sanpaiGo)はコールドスタートが短く参拝処理が速くなるため使用する
       // (Node版のsanpaiとレスポンス形式は同一。docs/backend.md参照)
-      let response = await this.$axios.post("sanpaiGo",
-        payload,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`
-          }
-        })
-        .catch(e=>{
-          this.$store.dispatch('logout');
-          this.isLoading = false;
-        })
-      if (response) {
-        const d = response.data;
-        this.status.level = d.level;
-        this.status.get = d.add_exp;
-        this.status.point = d.exp;
-        this.status.msg = d.msg;
-        this.status.pointsBefore = d.points_before != null ? d.points_before : 0;
-        this.status.pointsAfter = d.points_after != null ? d.points_after : d.exp;
-        this.status.powerBefore = d.power_before != null ? d.power_before : 0;
-        this.status.powerAfter = d.power_after != null ? d.power_after : 0;
-        this.status.levelBefore = d.level_before != null ? d.level_before : 0;
-        this.status.levelAfter = d.level_after != null ? d.level_after : d.level;
-        this.status.updatedRepoCount = d.updated_repo_count != null ? d.updated_repo_count : 0;
-        this.status.actionCount = d.action_count != null ? d.action_count : 0;
-        this.result = d.status;
-        this.isLoading = false;
-        if (d.status === "success") {
-          // クールダウン内の再マウントで完了画面を復元できるよう保存(#198)
-          saveSanpaiResult({ ...this.status }, d.next_time, Date.now());
+      let response;
+      try {
+        response = await this.$axios.post("sanpaiGo",
+          payload,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`
+            }
+          });
+      } catch (e) {
+        // ログアウトは認証エラー(401/403)のときだけ。ネットワーク瞬断や5xxで
+        // ログアウトさせると、再サインイン→再参拝→expireの悪循環になる(#198)
+        const statusCode = e.response && e.response.status;
+        if (statusCode === 401 || statusCode === 403) {
+          this.$store.dispatch("logout");
+        } else {
+          this.isError = true;
         }
-      } else {
-        this.isError = true;
         this.isLoading = false;
+        return;
+      }
+      const d = response.data;
+      this.status.level = d.level;
+      this.status.get = d.add_exp;
+      this.status.point = d.exp;
+      this.status.msg = d.msg;
+      this.status.pointsBefore = d.points_before != null ? d.points_before : 0;
+      this.status.pointsAfter = d.points_after != null ? d.points_after : d.exp;
+      this.status.powerBefore = d.power_before != null ? d.power_before : 0;
+      this.status.powerAfter = d.power_after != null ? d.power_after : 0;
+      this.status.levelBefore = d.level_before != null ? d.level_before : 0;
+      this.status.levelAfter = d.level_after != null ? d.level_after : d.level;
+      this.status.updatedRepoCount = d.updated_repo_count != null ? d.updated_repo_count : 0;
+      this.status.actionCount = d.action_count != null ? d.action_count : 0;
+      this.result = d.status;
+      this.isLoading = false;
+      if (d.status === "success") {
+        // クールダウン内の再マウントで完了画面を復元できるよう保存(#198)
+        saveSanpaiResult({ ...this.status }, d.next_time, Date.now());
       }
     },
   },

--- a/web/plugins/sw-update.client.js
+++ b/web/plugins/sw-update.client.js
@@ -4,8 +4,16 @@
 // activate して開いているタブの制御を奪う(controllerchange が発火する)。
 // ここではその切替を検知して自動リロードし、さらに開いたままのタブでも
 // 新デプロイを検知できるよう定期的に update() を呼ぶ。
-export default () => {
+//
+// ただし参拝の儀式〜参拝API実行中にリロードすると儀式画面からやり直しになり、
+// 再拍手→expire の原因になる(#198)。画面側が window.$swReloadGuard.blocked を
+// 立てている間はリロードを保留し、ブロック解除後の画面遷移時に実施する。
+export default ({ app }) => {
   if (!("serviceWorker" in navigator)) return;
+
+  // 「今リロードされると困る」画面(参拝の儀式中など)が blocked を立てるガード
+  const guard = { blocked: false, pending: false };
+  window.$swReloadGuard = guard;
 
   // プラグイン起動時点で既に SW に制御されているか。
   // 初回インストール(制御なし→あり)ではリロード不要なため区別する。
@@ -14,6 +22,12 @@ export default () => {
   let hasController = !!navigator.serviceWorker.controller;
 
   let reloading = false;
+  const reload = () => {
+    if (reloading) return;
+    reloading = true;
+    window.location.reload();
+  };
+
   navigator.serviceWorker.addEventListener("controllerchange", () => {
     if (!hasController) {
       // 初回インストールによる制御開始。リロードは不要だが、次回以降の
@@ -21,10 +35,22 @@ export default () => {
       hasController = true;
       return;
     }
-    if (reloading) return;
-    reloading = true;
-    window.location.reload();
+    if (guard.blocked) {
+      guard.pending = true;
+      return;
+    }
+    reload();
   });
+
+  // 保留したリロードは画面遷移後に実施(表示中の儀式・結果を突然消さない)
+  if (app.router) {
+    app.router.afterEach(() => {
+      if (guard.pending && !guard.blocked) {
+        guard.pending = false;
+        reload();
+      }
+    });
+  }
 
   navigator.serviceWorker.ready.then((registration) => {
     const checkForUpdate = () => {

--- a/web/utils/sanpaiSession.js
+++ b/web/utils/sanpaiSession.js
@@ -1,0 +1,97 @@
+// 参拝結果のローカル永続化(#198)。
+//
+// 儀式画面フラグ(ritual)は sanpai.vue のローカルstateのため、SWの自動リロード・
+// PWA再起動・モバイルのタブ退避復帰などで再マウントされると、参拝直後でも
+// 儀式画面に戻ってしまい、再度二拍手するとサーバー判定で expire になる。
+// これを防ぐため、参拝成功の結果をlocalStorageに保存し、クールダウン内の
+// 再マウントでは完了画面を復元する。
+//
+// 判定ロジックは storage を注入できる純関数にしてあり、Nodeで決定論的に
+// 検証できる(sanpaiGrass.js と同じ流儀)。
+
+var STORAGE_KEY = "debug-shrine:last-sanpai-result";
+
+// サーバー(SANPAI_NEXT_TIME_SECONDS)の既定値と同じ。応答に next_time が
+// 含まれない旧デプロイへのフォールバック。
+var DEFAULT_NEXT_TIME_SECONDS = 60;
+
+function defaultStorage() {
+  // プライベートモード等で localStorage が使えない環境では保存を諦める
+  try {
+    return window.localStorage;
+  } catch (e) {
+    return null;
+  }
+}
+
+// 参拝成功時に呼ぶ。status は完了画面の表示に必要な値一式(プレーンオブジェクト)。
+function saveSanpaiResult(status, nextTimeSeconds, now, storage) {
+  storage = storage || defaultStorage();
+  if (!storage) return;
+  var record = {
+    savedAt: now,
+    nextTime:
+      nextTimeSeconds != null ? nextTimeSeconds : DEFAULT_NEXT_TIME_SECONDS,
+    status: status,
+  };
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(record));
+  } catch (e) {
+    // 容量超過等。保存できなくても参拝自体は成立しているので黙って続行
+  }
+}
+
+// マウント時に呼ぶ。クールダウン内なら保存した status を返し、
+// 期限切れ・壊れたデータは削除して null を返す。
+function loadRestorableSanpaiResult(now, storage) {
+  storage = storage || defaultStorage();
+  if (!storage) return null;
+  var raw;
+  try {
+    raw = storage.getItem(STORAGE_KEY);
+  } catch (e) {
+    return null;
+  }
+  if (!raw) return null;
+  var record;
+  try {
+    record = JSON.parse(raw);
+  } catch (e) {
+    clearSanpaiResult(storage);
+    return null;
+  }
+  if (
+    !record ||
+    typeof record.savedAt !== "number" ||
+    typeof record.nextTime !== "number" ||
+    !record.status
+  ) {
+    clearSanpaiResult(storage);
+    return null;
+  }
+  var expiresAt = record.savedAt + record.nextTime * 1000;
+  // 端末時計が巻き戻っている場合(savedAt が未来)も復元せず捨てる
+  if (now < record.savedAt || now >= expiresAt) {
+    clearSanpaiResult(storage);
+    return null;
+  }
+  return record.status;
+}
+
+function clearSanpaiResult(storage) {
+  storage = storage || defaultStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(STORAGE_KEY);
+  } catch (e) {
+    // noop
+  }
+}
+
+module.exports = {
+  STORAGE_KEY: STORAGE_KEY,
+  DEFAULT_NEXT_TIME_SECONDS: DEFAULT_NEXT_TIME_SECONDS,
+  saveSanpaiResult: saveSanpaiResult,
+  loadRestorableSanpaiResult: loadRestorableSanpaiResult,
+  clearSanpaiResult: clearSanpaiResult,
+};


### PR DESCRIPTION
Closes #198

## 問題

参拝(二拍手)を完了したのに、SWの自動リロード・PWA再起動・タブ退避復帰などで `sanpai.vue` が再マウントされると儀式画面に戻ってしまい、もう一度二拍手するとサーバーのクールダウン判定(`last_sanpai + NextTime`)で expire 表示になっていた。また参拝APIの失敗時は種類を問わず logout していた。

## 変更内容(1修正=1コミット)

1. **feat(functions-go)**: 参拝レスポンス(success/expire)に `next_time`(クールダウン秒数)を追加。クライアントが復元期間を判定できるようにする。
2. **fix(web)**: 参拝成功結果を localStorage に保存(`web/utils/sanpaiSession.js` 新規)し、クールダウン内の再マウントでは儀式画面ではなく完了画面を復元。`next_time` 未提供の旧応答は60秒フォールバック。端末時計の巻き戻り・壊れたデータは破棄。
3. **fix(web)**: 参拝APIエラーで一律ログアウトせず、401/403 のときだけ logout。それ以外(ネットワーク瞬断・5xx)は再試行ボタン付きのエラー表示。共有UI・導線は結果確定後のみ表示。
4. **fix(web)**: 儀式中〜参拝API実行中は `window.$swReloadGuard` で SW 自動リロードを保留し、ブロック解除後の画面遷移時に実施(`web/plugins/sw-update.client.js`)。

## 検証

- `web/utils/sanpaiSession.js` を Node で決定論的に検証(クールダウン内復元・期限切れ破棄・旧応答フォールバック・時計巻き戻り・壊れたJSON・localStorage 不可環境の8ケース、全パス)
- `go test ./...`(functions-go)全パス
- CI相当の `yarn install --frozen-lockfile && yarn generate`(node:18)成功
- `yarn.lock` / `package-lock.json` への差分なし

## 動作確認手順(レビュー用)

1. 参拝成功 → ブラウザリロード → 完了画面が復元されること(修正前は儀式画面に戻り、二拍手で expire)
2. DevTools オフラインで参拝 → ログアウトされず再試行UIが出ること
3. クールダウン経過後は通常どおり新規参拝できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NjEjZtmCpVdJtCeFumYzG
