### PR TITLE
登録失敗の無言化と「not registered」詰み状態を修正 (#205)

### DIFF
--- a/app/functions-go/register.go
+++ b/app/functions-go/register.go
@@ -77,6 +77,21 @@ func registerHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if body.GithubID == "" || body.DisplayName == "" || body.ScreenName == "" || body.ImagePath == "" {
+		// どのフィールドが欠けたかログに残す(値は出さない)。無言で失敗すると
+		// 「Authにアカウントだけあり users ドキュメントが無い」詰み状態の
+		// 原因調査ができない(#205)
+		var missing []string
+		for name, v := range map[string]string{
+			"github_id":    body.GithubID,
+			"display_name": body.DisplayName,
+			"screen_name":  body.ScreenName,
+			"image_path":   body.ImagePath,
+		} {
+			if v == "" {
+				missing = append(missing, name)
+			}
+		}
+		log.Printf("register: failed parameter (missing: %v)", missing)
 		writeJSON(w, http.StatusOK, map[string]string{"status": "failed parameter"})
 		return
 	}

--- a/web/nuxt.config.js
+++ b/web/nuxt.config.js
@@ -104,7 +104,10 @@ export default {
       {
         persistence: 'local', // default
         ssr: false, // default
-        emulatorPort: 9099,
+        // ホスト側の9099が他プロジェクトに使われている場合に上書きできるようにする
+        emulatorPort: process.env.FIREBASE_AUTH_EMULATOR_PORT
+          ? parseInt(process.env.FIREBASE_AUTH_EMULATOR_PORT, 10)
+          : 9099,
         emulatorHost: 'http://localhost',
       }
     }

--- a/web/pages/index.vue
+++ b/web/pages/index.vue
@@ -218,11 +218,19 @@ export default {
         console.error(error);
         return;
       }
+      // auth エミュレーターの偽GitHubサインインは screenName / photoURL を
+      // 返さないため、ローカル検証用のフォールバックを入れる(実GitHubでは
+      // 常に値が入るため本番の挙動は変わらない)(#205)
+      const provData = result.user.providerData[0] || {};
       let userData = {
-        github_id: result.user.providerData[0].uid,
+        github_id: provData.uid || result.user.uid,
         display_name: result.user.displayName,
-        screen_name: result._tokenResponse.screenName,
-        image_path: result.user.photoURL,
+        screen_name:
+          result._tokenResponse.screenName ||
+          (result.user.email ? result.user.email.split("@")[0] : "local-dev"),
+        image_path:
+          result.user.photoURL ||
+          "https://avatars.githubusercontent.com/u/583231",
       };
 
       if (!userData.display_name) {

--- a/web/pages/index.vue
+++ b/web/pages/index.vue
@@ -30,6 +30,9 @@
             >
               GitHubと連携して<br class="d-md-none" />参拝しよう
             </button>
+            <div v-if="registerError" class="alert alert-warning mt-3 mb-0">
+              登録に失敗しました。時間をおいて、もう一度GitHub連携からやり直してください。
+            </div>
           </div>
           <div class="mt-4" v-else>
             <div>
@@ -154,6 +157,8 @@ export default {
       buttons: {
         sanpai: false,
       },
+      // 登録API(registerGo)が失敗したときの表示フラグ(#205)
+      registerError: false,
       // らぼみの吹き出し。SSR/CSRの差異を避けるため mounted で選ぶ(初期は空)。
       labomiLine: "",
     };
@@ -195,48 +200,59 @@ export default {
       const pool = this.isLogin ? member : guest;
       this.labomiLine = pool[Math.floor(Math.random() * pool.length)];
     },
-    GitHubAuth() {
+    async GitHubAuth() {
       this.buttons.sanpai = true;
       const provider = new GithubAuthProvider();
       const auth = getAuth();
       if (this.isLogin) {
         //認証済み
         this.$router.push({ path: "/sanpai" });
-      } else {
-        //未認証
-        signInWithPopup(auth, provider)
-          .then((result) => {
-            let userData = {
-              github_id: result.user.providerData[0].uid,
-              display_name: result.user.displayName,
-              screen_name: result._tokenResponse.screenName,
-              image_path: result.user.photoURL,
-            };
+        return;
+      }
+      //未認証
+      this.registerError = false;
+      let result;
+      try {
+        result = await signInWithPopup(auth, provider);
+      } catch (error) {
+        console.error(error);
+        return;
+      }
+      let userData = {
+        github_id: result.user.providerData[0].uid,
+        display_name: result.user.displayName,
+        screen_name: result._tokenResponse.screenName,
+        image_path: result.user.photoURL,
+      };
 
-            if (!userData.display_name) {
-              userData.display_name = userData.screen_name;
-            }
-            this.$store.commit("setUser", userData);
-            getAuth()
-              .currentUser.getIdToken()
-              .then((token) => {
-                this.$store.commit("setToken", token);
-                // Go版(registerGo)はコールドスタートが短くログイン直後の登録が
-                // 速くなるため使用する(Node版のregisterとレスポンス形式は同一。
-                // docs/backend.md参照)
-                this.$axios.post("registerGo", userData, {
-                  headers: {
-                    Authorization: `Bearer ${token}`,
-                  },
-                });
-              })
-              .catch((e) => {
-                console.log(e);
-              });
-          })
-          .catch((error) => {
-            console.error(error);
-          });
+      if (!userData.display_name) {
+        userData.display_name = userData.screen_name;
+      }
+      this.$store.commit("setUser", userData);
+      try {
+        const token = await auth.currentUser.getIdToken();
+        this.$store.commit("setToken", token);
+        // Go版(registerGo)はコールドスタートが短くログイン直後の登録が
+        // 速くなるため使用する(Node版のregisterとレスポンス形式は同一。
+        // docs/backend.md参照)
+        const res = await this.$axios.post("registerGo", userData, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        // success(新規)/ registered(登録済み)/ updated(uid補完)以外は登録失敗
+        const status = res && res.data && res.data.status;
+        if (!["success", "registered", "updated"].includes(status)) {
+          throw new Error("register failed: " + status);
+        }
+      } catch (e) {
+        // 登録に失敗したままログイン状態にすると、以後すべてのAPIが
+        // not registered を返す詰み状態になる(#205)。サインアウトして
+        // エラーを表示し、やり直せるようにする。
+        console.error(e);
+        this.registerError = true;
+        this.$store.dispatch("logout");
+        return;
       }
     },
     sanpai() {

--- a/web/pages/sanpai.vue
+++ b/web/pages/sanpai.vue
@@ -134,6 +134,19 @@
         </div>
         <div class="fs-4 mt-4">追加のポイントはありませんでした</div>
       </div>
+      <!-- failed(not registered 等)や未知のステータス。以前は表示分岐が無く
+           真っ白になっていた(#205) -->
+      <div v-else-if="result">
+        <div class="fs-1 mt-5">
+          「ふむ、まだ氏子の登録が済んでおらぬようじゃ。」
+        </div>
+        <div class="fs-4 mt-4">
+          参拝を受け付けられませんでした。トップページからログインし直してください。
+        </div>
+        <nuxt-link class="btn btn-lg btn-accent mt-4" to="/">
+          トップページへ戻る
+        </nuxt-link>
+      </div>
       </transition>
     </div>
     <!-- 通信失敗(ネットワーク瞬断・サーバーエラー)。儀式はやり直させない -->
@@ -150,8 +163,10 @@
         もう一度参拝する
       </button>
     </div>
-    <!-- 参拝前(儀式中)・結果未確定のうちは共有UIや導線を出さない -->
-    <template v-if="!ritual && result">
+    <!-- 参拝前(儀式中)・結果未確定・失敗時は共有UIや導線を出さない -->
+    <template
+      v-if="!ritual && ['success', 'expire', 'noaction'].includes(result)"
+    >
       <div class="my-5">
         <Share
           title="参拝したことをSNSで報告しよう"


### PR DESCRIPTION
Closes #205

## 問題

登録API(`registerGo`)が失敗しても、フロントが検知せずログイン状態になり、以後すべてのAPIが `not registered` を返す詰み状態に陥っていた。参拝画面は `failed` の表示分岐がなく真っ白になっていた。また `register.go` はパラメータ不足時にログを出さず、原因調査ができなかった(ローカル検証で実際に発生)。

## 変更内容(1修正=1コミット)

1. **fix(functions-go)**: `failed parameter` 時に欠落フィールド名をログ出力(値は出さない)
2. **fix(web)**: `registerGo` を await して結果検証。`success`/`registered`/`updated` 以外はサインアウト+エラーメッセージ表示でやり直せるようにする(index.vue)
3. **fix(web)**: 参拝結果 `failed`(not registered 等)・未知ステータスの案内表示+トップへの導線を追加。共有UIは正常系のみ表示(sanpai.vue)
4. **fix(web)**: auth エミュレーター互換 — 偽GitHubサインインが `screenName`/`photoURL` を返さず登録が構造的に失敗する問題のフォールバック(実GitHubでは値が入るため本番挙動は不変)+ `FIREBASE_AUTH_EMULATOR_PORT` でエミュレーターポートを上書き可能に

自動再登録(Issue の対応案③)は方針判断待ちのため本PRには含めていない。

## 検証

- `go test ./...` 全パス
- CI相当の `yarn generate`(node:18)成功、`yarn.lock` 差分なし
- ローカルエミュレーター環境で「Authアカウントのみ・usersドキュメント無し」の詰み状態を再現済み(Issue #205 のコメント参照)。本修正で登録失敗が可視化され、参拝画面も案内表示になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NjEjZtmCpVdJtCeFumYzG
