### PR TITLE
PWA起動時に前回の途中画面が復元されるのを防ぐ (#197)

### DIFF
--- a/web/nuxt.config.js
+++ b/web/nuxt.config.js
@@ -67,6 +67,7 @@ export default {
   plugins: [
     '~/plugins/persistedstate.js',
     '~/plugins/sw-update.client.js',
+    '~/plugins/pwa-start.client.js',
   ],
 
   // Auto import components (https://go.nuxtjs.dev/config-components)

--- a/web/plugins/pwa-start.client.js
+++ b/web/plugins/pwa-start.client.js
@@ -1,0 +1,32 @@
+// PWA(standalone表示)起動時に前回表示していたURLが復元される問題への対策(#197)。
+//
+// manifest の start_url は "/" だが、OSやブラウザは「最後に表示していたURL」で
+// アプリを復元することがあり、おみくじ・参拝の途中画面から始まってしまう。
+// セッション初回(=アプリの起動)かつ standalone 表示で、途中画面にいる場合
+// だけトップへ戻す。タブ切替や同一セッション内の遷移では何もしない。
+export default ({ app }) => {
+  const isStandalone =
+    (window.matchMedia &&
+      window.matchMedia("(display-mode: standalone)").matches) ||
+    // iOS Safari のホーム画面起動
+    window.navigator.standalone === true;
+  if (!isStandalone) return;
+
+  const KEY = "debug-shrine:pwa-session-started";
+  let started = null;
+  try {
+    // sessionStorage はアプリの再起動で消えるため「起動直後」の判定に使える
+    started = sessionStorage.getItem(KEY);
+    sessionStorage.setItem(KEY, "1");
+  } catch (e) {
+    return; // storage が使えない環境では何もしない
+  }
+  if (started) return;
+
+  // 状態を持つ途中画面だけ start_url へ戻す(結果表示等は各画面が自力復元する)
+  const MID_FLOW_PATHS = ["/omikuji", "/sanpai"];
+  const path = window.location.pathname.replace(/\/$/, "") || "/";
+  if (MID_FLOW_PATHS.includes(path) && app.router) {
+    app.router.replace("/");
+  }
+};


### PR DESCRIPTION
Closes #197

## 問題

PWA(ホーム画面追加/standalone表示)から起動すると、manifest の `start_url: "/"` ではなく前回表示していたURL(おみくじ・参拝画面)が復元されてしまう。OSやブラウザが「最後に表示していたURL」でアプリを復元するためで、クライアント側に起動時の画面リセット処理がなかった。

## 変更内容

`web/plugins/pwa-start.client.js` を追加:

- standalone 表示(`display-mode: standalone` / iOS の `navigator.standalone`)を検知
- `sessionStorage` で「セッション初回=アプリ起動直後」を判定(タブ切替・同一セッション内の遷移では何もしない)
- 起動直後に途中画面(`/omikuji`・`/sanpai`)にいる場合だけトップへ `router.replace`

なお Issue 起票時に挙げた自己破壊型SW(`web/static/sw.js`)は **gitignore 済みのローカル生成物**で、リポジトリに存在せず本番にも出荷されていないことを確認した(本番配信中の `/sw.js` は PWA モジュール生成の workbox 版)。よって本PRでの削除対象はない。

参拝画面の途中状態は #198(マージ済み)のローカル復元が担うため、本プラグインは「起動画面をトップに揃える」ことに専念している。

## 検証

- CI相当の `yarn generate`(node:18)成功、`yarn.lock` 差分なし
- 実機確認手順: Android Chrome / iOS Safari でホーム画面に追加 → `/omikuji` を表示したままアプリを完全終了 → 再起動でトップが表示されること。通常のブラウザタブではリロード・戻る操作で従来どおり現在URLが維持されること(standalone 以外では何もしないため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NjEjZtmCpVdJtCeFumYzG
