### PR TITLE
フォールバック時の注記を赤くして目立たせる

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -13,6 +13,7 @@ colors:
   accent-soft: "#ffcf6b"
   accent-tint: "rgba(255, 196, 120, 0.15)" # 選択状態の面(タブ・ピン選択行など)
   on-accent: "#1a1206" # 琥珀の上に載せる文字色
+  danger: "#ff6b6b" # 注意喚起(エラー・警告)。暗い背景で読めるよう純赤より明るく
 typography:
   font-family-sans: '"Helvetica Neue", Helvetica, Arial, "Hiragino Kaku Gothic ProN", Meiryo, sans-serif'
   font-family-mono: 'SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace'
@@ -54,6 +55,8 @@ GitHubのダークUIに寄せたカード(`--color-surface: #0d1117`)を置き�
 - 面: `--color-surface`(#0d1117)+ 枠線 `--color-surface-border`(#30363d)
 - アクセント(琥珀): ボタン面は `--color-accent`、hoverは `--color-accent-hover`、
   文字強調は `--color-accent-soft`。琥珀の上の文字は `#1a1206`(焦げ茶)
+- 注意喚起(エラー・警告)は `--color-danger`(#ff6b6b)。読み飛ばされると困る
+  ものは文字色だけでなく、同色のボーダー+薄いティントの面で囲って目立たせる
 - 選択状態の面は琥珀の薄いティント `rgba(255,196,120,.15)`(タブのactive、
   ピン留め候補の選択行などで共通)
 - SNSブランド色は `color.css` の `--color-x` 等を使う(独自の近似色を作らない)

--- a/web/assets/css/color.css
+++ b/web/assets/css/color.css
@@ -16,6 +16,9 @@
   --color-accent-hover: #c98f2a;
   --color-accent-soft: #ffcf6b;
 
+  /* 注意喚起(エラー・警告)。暗い背景で読めるよう純赤より明るくする */
+  --color-danger: #ff6b6b;
+
   /* SNSブランド色 */
   --color-x: #000000;
   --color-bluesky: #0085ff;

--- a/web/components/Ranking.vue
+++ b/web/components/Ranking.vue
@@ -33,8 +33,10 @@
       </div>
     </template>
 
-    <!-- 期間の記録がまだ無いときは黙って空を出さず、トータルを見せる -->
+    <!-- 期間の記録がまだ無いときは黙って空を出さず、トータルを見せる。
+         見ているものが選択中のタブと違うので、赤字で目立たせる -->
     <div v-if="fellBack" class="fallback-note mb-3">
+      <i class="fas fa-fw fa-exclamation-triangle"></i>
       まだ{{ periodLabel }}の記録が溜まっていないため、トータルを表示しています。
     </div>
 
@@ -251,8 +253,13 @@ export default {
   font-size: 0.9rem;
 }
 .fallback-note {
-  color: var(--color-text-muted, #9a9a9a);
-  font-size: 0.85rem;
+  color: var(--color-danger, #ff6b6b);
+  border: 1px solid var(--color-danger, #ff6b6b);
+  border-radius: 0.5rem;
+  background: rgba(255, 107, 107, 0.1);
+  padding: 8px 12px;
+  font-size: 0.9rem;
+  font-weight: 700;
 }
 
 /* 指標(せんとうりょく/ぽいんと)と期間(トータル/週間/月間)の切替。


### PR DESCRIPTION
「まだ週間の記録が溜まっていないため、トータルを表示しています」がグレーの小さい文字で気付かれませんでした。**選択中のタブと表示内容が食い違っている**ことを伝える重要な注記なので、目立つようにします。

- 赤字(`--color-danger`)+ 同色ボーダー + 薄いティントの面 + 警告アイコンで囲う
- 太字・0.9rem に拡大

色は `color.css` に **`--color-danger: #ff6b6b`** を追加してトークン化しました(暗い背景で読めるよう純赤より明るめ)。DESIGN.md にも「注意喚起は `--color-danger`。読み飛ばされると困るものは文字色だけでなく面で囲う」として明文化しています。

`yarn generate` 成功。ヘッドレスで表示確認済み。

参考: `RepoPicker.vue` の保存エラーが `#ff8080` を直書きしているので、後で `--color-danger` に寄せると統一できます(今回のスコープ外)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_