### PR TITLE
エラー・注意喚起の表示を .notice-danger に統一

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -101,6 +101,9 @@ GitHubのダークUIに寄せたカード(`--color-surface: #0d1117`)を置き�
 - **アイコンはFontAwesome単色**(`fas fa-fw fa-*`)で文字色に追従させる。
   **絵文字は使わない**(機種依存の見た目になる。#182でタブの絵文字を
   fa-fist-raised / fa-coins に置換した経緯)。既存の残存箇所は #183 で置き換える
+- **注意喚起** `.notice-danger`(common.css): 読み込み失敗・保存失敗・表示内容の
+  食い違いなど、読み飛ばされると困る知らせ。赤字+同色ボーダー+薄い面+
+  `fa-exclamation-triangle`。Bootstrapの `alert` は白背景なので使わない
 - **進捗バー**: `.progress-bar` は琥珀
 
 ## Do's and Don'ts

--- a/web/assets/css/common.css
+++ b/web/assets/css/common.css
@@ -75,3 +75,17 @@ code {
     background-color: var(--color-accent);
     color: #1a1206;
 }
+
+/* 注意喚起(読み込み失敗・保存失敗・表示内容の食い違いなど)。
+   読み飛ばされると困るものは文字色だけでなく面で囲う(DESIGN.md参照)。
+   Bootstrapのalertは白背景なのでダークテーマでは使わず、これに統一する */
+.notice-danger {
+    display: block;
+    color: var(--color-danger);
+    border: 1px solid var(--color-danger);
+    border-radius: 0.5rem;
+    background: rgba(255, 107, 107, 0.1);
+    padding: 8px 12px;
+    font-size: 0.9rem;
+    font-weight: 700;
+}

--- a/web/components/GithubStats.vue
+++ b/web/components/GithubStats.vue
@@ -11,8 +11,8 @@
       GitHubの実績を集めています<span class="dots"></span>
     </div>
     <div v-else-if="state === 'error'" class="py-2">
-      <span class="gh-sub">GitHubの実績を読み込めませんでした。</span>
-      <button class="btn btn-sm btn-outline-light ms-2" @click="fetchStats">
+      <span class="notice-danger"><i class="fas fa-fw fa-exclamation-triangle"></i> GitHubの実績を読み込めませんでした。</span>
+      <button class="btn btn-sm btn-outline-light mt-2" @click="fetchStats">
         再読み込み
       </button>
     </div>

--- a/web/components/ProfileStats.vue
+++ b/web/components/ProfileStats.vue
@@ -8,8 +8,8 @@
       記録を紐解いています<span class="dots"></span>
     </div>
     <div v-else-if="state === 'error'" class="py-2">
-      <span class="stats-sub">記録を読み込めませんでした。</span>
-      <button class="btn btn-sm btn-outline-light ms-2" @click="fetchStats">
+      <span class="notice-danger"><i class="fas fa-fw fa-exclamation-triangle"></i> 記録を読み込めませんでした。</span>
+      <button class="btn btn-sm btn-outline-light mt-2" @click="fetchStats">
         再読み込み
       </button>
     </div>

--- a/web/components/Ranking.vue
+++ b/web/components/Ranking.vue
@@ -35,7 +35,7 @@
 
     <!-- 期間の記録がまだ無いときは黙って空を出さず、トータルを見せる。
          見ているものが選択中のタブと違うので、赤字で目立たせる -->
-    <div v-if="fellBack" class="fallback-note mb-3">
+    <div v-if="fellBack" class="notice-danger mb-3">
       <i class="fas fa-fw fa-exclamation-triangle"></i>
       まだ{{ periodLabel }}の記録が溜まっていないため、トータルを表示しています。
     </div>
@@ -251,15 +251,6 @@ export default {
 .ranking-empty {
   color: var(--color-text-muted, #9a9a9a);
   font-size: 0.9rem;
-}
-.fallback-note {
-  color: var(--color-danger, #ff6b6b);
-  border: 1px solid var(--color-danger, #ff6b6b);
-  border-radius: 0.5rem;
-  background: rgba(255, 107, 107, 0.1);
-  padding: 8px 12px;
-  font-size: 0.9rem;
-  font-weight: 700;
 }
 
 /* 指標(せんとうりょく/ぽいんと)と期間(トータル/週間/月間)の切替。

--- a/web/components/RepoPicker.vue
+++ b/web/components/RepoPicker.vue
@@ -14,8 +14,8 @@
       リポジトリ一覧を取得しています<span class="dots"></span>
     </div>
     <div v-else-if="state === 'error'" class="py-2">
-      <span class="picker-sub">一覧を取得できませんでした(GitHub APIの制限の可能性)。</span>
-      <button class="btn btn-sm btn-outline-light ms-2" @click="fetchCandidates">
+      <span class="notice-danger"><i class="fas fa-fw fa-exclamation-triangle"></i> 一覧を取得できませんでした(GitHub APIの制限の可能性)。</span>
+      <button class="btn btn-sm btn-outline-light mt-2" @click="fetchCandidates">
         もう一度
       </button>
     </div>
@@ -69,9 +69,9 @@
         >
           おまかせ(スター上位)に戻す
         </button>
-        <span v-if="saveState === 'error'" class="picker-error">{{
-          saveError
-        }}</span>
+        <span v-if="saveState === 'error'" class="notice-danger">
+          <i class="fas fa-fw fa-exclamation-triangle"></i> {{ saveError }}
+        </span>
       </div>
     </template>
   </div>
@@ -194,10 +194,6 @@ export default {
 .picker-sub {
   color: var(--color-text-muted, #9a9a9a);
   font-size: 0.82rem;
-}
-.picker-error {
-  color: #ff8080;
-  font-size: 0.85rem;
 }
 
 .candidates {

--- a/web/components/SanpaiGrass.vue
+++ b/web/components/SanpaiGrass.vue
@@ -12,8 +12,8 @@
       草を数えています<span class="dots"></span>
     </div>
     <div v-else-if="state === 'error'" class="py-2">
-      <span class="grass-sub">参拝履歴を読み込めませんでした。</span>
-      <button class="btn btn-sm btn-outline-light ms-2" @click="fetchRecent">
+      <span class="notice-danger"><i class="fas fa-fw fa-exclamation-triangle"></i> 参拝履歴を読み込めませんでした。</span>
+      <button class="btn btn-sm btn-outline-light mt-2" @click="fetchRecent">
         再読み込み
       </button>
     </div>
@@ -42,8 +42,8 @@
           全期間の参拝を解析しています<span class="dots"></span>
         </div>
         <div v-else-if="allState === 'error'" class="py-2">
-          <span class="grass-sub">全期間の解析に失敗しました。</span>
-          <button class="btn btn-sm btn-outline-light ms-2" @click="loadAll">
+          <span class="notice-danger"><i class="fas fa-fw fa-exclamation-triangle"></i> 全期間の解析に失敗しました。</span>
+          <button class="btn btn-sm btn-outline-light mt-2" @click="loadAll">
             もう一度
           </button>
         </div>

--- a/web/pages/index.vue
+++ b/web/pages/index.vue
@@ -30,8 +30,8 @@
             >
               GitHubと連携して<br class="d-md-none" />参拝しよう
             </button>
-            <div v-if="registerError" class="alert alert-warning mt-3 mb-0">
-              登録に失敗しました。時間をおいて、もう一度GitHub連携からやり直してください。
+            <div v-if="registerError" class="notice-danger mt-3">
+              <i class="fas fa-fw fa-exclamation-triangle"></i> 登録に失敗しました。時間をおいて、もう一度GitHub連携からやり直してください。
             </div>
           </div>
           <div class="mt-4" v-else>

--- a/web/pages/omikuji.vue
+++ b/web/pages/omikuji.vue
@@ -8,8 +8,8 @@
 
     <!-- エラー -->
     <div v-else-if="state === 'error'" class="my-5">
-      <div class="alert alert-warning">
-        うまく引けませんでした。時間をおいて試してください。
+      <div class="notice-danger">
+        <i class="fas fa-fw fa-exclamation-triangle"></i> うまく引けませんでした。時間をおいて試してください。
       </div>
       <button class="btn btn-outline-secondary" @click="fetchStatus">
         再読み込み


### PR DESCRIPTION
#213 でランキングの注記を赤くした流れで、同じ「うまくいかなかった」の知らせが**3通りの見た目に分かれていた**のを1つに揃えます。

| 変更前 | 箇所 |
|---|---|
| 灰色の補足テキスト(本文と同化して見落とす) | 参拝の草・参拝の記録・GitHub実績・リポジトリ一覧の読み込み失敗、全期間解析の失敗 |
| `#ff8080` の直書き | ピン留めの保存失敗 |
| Bootstrap の `alert alert-warning`(白背景でダークテーマから浮く) | 登録失敗(トップ)、おみくじの取得失敗 |

## 変更後

`common.css` に **`.notice-danger`** を用意して全部そこに寄せました。

- 赤字(`--color-danger`)+ 同色ボーダー + 薄い面 + `fa-exclamation-triangle`
- 再読み込み/もう一度ボタンは面の**外(下)**に置いて、文とボタンの区別を付ける
- DESIGN.md の Components に部品として明記し、「Bootstrapの `alert` は白背景なので使わない」も書き足し

DESIGN.md の既存ルール(「Bootstrap既定の白背景部品を素のまま使わない」「独自の色をハードコードしない」)に沿わせた形です。

`yarn generate` 成功。ヘッドレスで変更前後を並べて確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_