### PR TITLE
参拝結果の復元表示を「参拝済み」表示に変更し無限参拝に見える問題を解消 (#215)

### DIFF
--- a/web/pages/sanpai.vue
+++ b/web/pages/sanpai.vue
@@ -41,11 +41,18 @@
             style="max-width: 700px; height: auto"
           />
         </div>
-        <div class="fs-1">「殊勝なことじゃ。きっと良きことがあるぞよ。」</div>
+        <!-- 復元表示(参拝済み)では新規成功と同じ口上・演出を再生しない(#215) -->
+        <div class="fs-1">
+          {{
+            restored
+              ? "「先ほどの参拝の結果じゃ。」"
+              : "「殊勝なことじゃ。きっと良きことがあるぞよ。」"
+          }}
+        </div>
         <div class="fs-4 mt-4">{{ status.msg }}</div>
 
         <LevelUpBanner
-          v-if="isLevelUp"
+          v-if="isLevelUp && !restored"
           :from="status.levelBefore"
           :to="status.levelAfter"
         />
@@ -57,12 +64,14 @@
             <span class="text-muted">{{ status.pointsBefore.toLocaleString() }}</span>
             <span class="result-arrow">→</span>
             <CountUp
+              v-if="!restored"
               :from="status.pointsBefore"
               :value="status.pointsAfter"
               :delay="300"
               suffix=" pt"
             />
-            <span class="badge bg-success ms-2">+{{ status.get }}</span>
+            <span v-else>{{ status.pointsAfter.toLocaleString() }} pt</span>
+            <span v-if="!restored" class="badge bg-success ms-2">+{{ status.get }}</span>
           </div>
         </div>
 
@@ -73,11 +82,13 @@
             <span class="text-muted">{{ status.powerBefore.toLocaleString() }}</span>
             <span class="result-arrow">→</span>
             <CountUp
+              v-if="!restored"
               :from="status.powerBefore"
               :value="status.powerAfter"
               :delay="600"
             />
-            <span v-if="powerDelta > 0" class="badge bg-danger ms-2">
+            <span v-else>{{ status.powerAfter.toLocaleString() }}</span>
+            <span v-if="powerDelta > 0 && !restored" class="badge bg-danger ms-2">
               +{{ powerDelta }}
             </span>
           </div>
@@ -89,16 +100,23 @@
             <div class="mx-3">
               <div class="fs-6">更新リポジトリ</div>
               <div class="fs-3">
-                <CountUp :value="status.updatedRepoCount" :delay="900" />
+                <CountUp v-if="!restored" :value="status.updatedRepoCount" :delay="900" />
+                <span v-else>{{ status.updatedRepoCount }}</span>
               </div>
             </div>
             <div class="mx-3">
               <div class="fs-6">アクション</div>
               <div class="fs-3">
-                <CountUp :value="status.actionCount" :delay="900" />
+                <CountUp v-if="!restored" :value="status.actionCount" :delay="900" />
+                <span v-else>{{ status.actionCount }}</span>
               </div>
             </div>
           </div>
+        </div>
+
+        <!-- 次の参拝までのカウントダウン(復元表示のときだけ) -->
+        <div v-if="restored" class="fs-5 mt-4 text-muted">
+          次の参拝まで あと {{ remainingText }}
         </div>
 
       </div>
@@ -196,6 +214,7 @@ import { mapGetters } from "vuex";
 import {
   saveSanpaiResult,
   loadRestorableSanpaiResult,
+  clearSanpaiResult,
 } from "~/utils/sanpaiSession";
 
 // 認証状態の復元は非同期のため、最初に確定したユーザーを待ち受ける
@@ -222,6 +241,10 @@ export default {
       isLoading: false,
       isError: false,
       result: "",
+      // 復元表示(参拝済みの結果)かどうか。true の間は成功演出を再生しない(#215)
+      restored: false,
+      remainingSeconds: 0,
+      restoreTimerId: null,
       loadingMessages: [
         "ブンセキチュウ...",
         "コミットをかぞえています",
@@ -252,9 +275,13 @@ export default {
     // 戻すと二拍手→サーバー判定でexpireの悪循環になる(#198)
     const saved = loadRestorableSanpaiResult(Date.now());
     if (saved) {
+      // 復元表示は「参拝済みの結果」として見せる。新規成功と同じ演出を
+      // 再生すると、何度でも参拝できているように見えてしまう(#215)
       this.ritual = false;
       this.result = "success";
-      this.status = { ...this.status, ...saved };
+      this.restored = true;
+      this.status = { ...this.status, ...saved.status };
+      this.startRestoreCountdown(saved.remainingSeconds);
       return;
     }
     // 儀式〜参拝完了まではSWの自動リロードを保留させる(#198)
@@ -262,6 +289,7 @@ export default {
   },
   beforeDestroy() {
     if (this.clapTimerId) clearTimeout(this.clapTimerId);
+    if (this.restoreTimerId) clearInterval(this.restoreTimerId);
     this.setSwReloadBlocked(false);
   },
   methods: {
@@ -296,6 +324,23 @@ export default {
       this.isLoading = true;
       this.setSwReloadBlocked(true);
       this.doSanpai();
+    },
+    // 復元表示のカウントダウン。0になったら保存結果を破棄して
+    // 儀式(二拍手)からやり直せる状態に戻す(#215)
+    startRestoreCountdown(seconds) {
+      this.remainingSeconds = seconds;
+      this.restoreTimerId = setInterval(() => {
+        this.remainingSeconds -= 1;
+        if (this.remainingSeconds <= 0) {
+          clearInterval(this.restoreTimerId);
+          this.restoreTimerId = null;
+          clearSanpaiResult();
+          this.restored = false;
+          this.result = "";
+          this.ritual = true;
+          this.setSwReloadBlocked(true);
+        }
+      }, 1000);
     },
     // sw-update.client.js が公開するガード。儀式〜参拝API実行中の
     // SW自動リロードを保留する(#198)
@@ -378,6 +423,12 @@ export default {
     },
     isLevelUp() {
       return this.status.levelAfter > this.status.levelBefore;
+    },
+    remainingText() {
+      const s = Math.max(0, this.remainingSeconds);
+      const m = Math.floor(s / 60);
+      const sec = s % 60;
+      return m > 0 ? `${m}分${sec}秒` : `${sec}秒`;
     },
     shareUrl() {
       return this.$config.baseUrl;

--- a/web/utils/sanpaiSession.js
+++ b/web/utils/sanpaiSession.js
@@ -75,7 +75,11 @@ function loadRestorableSanpaiResult(now, storage) {
     clearSanpaiResult(storage);
     return null;
   }
-  return record.status;
+  return {
+    status: record.status,
+    // 「次の参拝まで」のカウントダウン表示用(#215)
+    remainingSeconds: Math.ceil((expiresAt - now) / 1000),
+  };
 }
 
 function clearSanpaiResult(storage) {


### PR DESCRIPTION
Closes #215

## 問題

#198 の完了画面復元(PR #202)により、クールダウン(本番5分)内に /sanpai を再訪するたびに成功演出(ポイントのカウントアップ・「+N」バッジ・レベルアップバナー)がフル再生され、**無限に参拝できているように見えて**いた。実際の付与はサーバーの `last_sanpai` ガードにより1回のみで、表示のみの問題(調査の詳細は #215)。

## 変更内容

復元表示を「新規の成功演出」から「**参拝済みの結果表示**」に変更:

- 口上を「先ほどの参拝の結果じゃ。」に変更
- カウントアップ・+Nバッジ・レベルアップバナーは復元時には再生せず、最終値を静的表示
- 「**次の参拝まで あと◯分◯秒**」のカウントダウンを表示(保存済みの `next_time` から算出)
- カウントダウンが0になったら保存結果を破棄し、儀式(二拍手)からやり直せる状態に自動で戻る
- 初回の参拝成功時は従来どおりフル演出(リグレッションなし)

## 検証

- `sanpaiSession.js` のNodeテスト8ケース全パス(返り値に remainingSeconds を追加)
- CI相当の `yarn generate`(node:18)成功、`yarn.lock` 差分なし

## 動作確認手順(レビュー用)

1. 参拝成功(フル演出)→ リロード → 「先ほどの参拝の結果じゃ」+静的数値+カウントダウンが表示され、演出が再生されないこと
2. カウントダウンが0になると儀式画面に戻り、通常どおり参拝できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NjEjZtmCpVdJtCeFumYzG