### PR TITLE
最初の週・月の締めに誤った注意書きが出るのを修正

### DIFF
--- a/app/functions-go/ranking_archive.go
+++ b/app/functions-go/ranking_archive.go
@@ -144,9 +144,15 @@ func baselineDeltas(base map[string]int64, users []rankingUpdateUserDoc) []perio
 // isPartialPeriod は基準値の作成が期間開始よりだいぶ後だったかを判定する。
 // ロールオーバーは期間開始直後の実行で起きるので、大きくずれているのは
 // 機能の導入直後や関数の長時間停止に限られる。
+//
+// 記録が無い(ゼロ値)場合は partial としない。base_at は締め機能と同時に
+// 足したフィールドで、期間ランキング自体はそれより前から動いている。つまり
+// ゼロ値は「途中から始めた」ではなく「フィールドを持つ前に作られた基準値」を
+// 意味する。ここで true にすると、頭から記録できている最初の週・月に
+// 誤った注意書きが出てしまう。
 func isPartialPeriod(baseAt, start time.Time) bool {
 	if baseAt.IsZero() {
-		return true
+		return false
 	}
 	return baseAt.After(start.Add(90 * time.Minute))
 }

--- a/app/functions-go/ranking_archive_test.go
+++ b/app/functions-go/ranking_archive_test.go
@@ -118,6 +118,20 @@ func TestDetectClosings_PartialWhenBaselineIsLate(t *testing.T) {
 	}
 }
 
+func TestDetectClosings_NotPartialWhenBaseAtIsMissing(t *testing.T) {
+	// base_at は締め機能と同時に足したフィールド。期間ランキングはそれより
+	// 前から動いているので、記録が無い基準値は「途中から始めた」ではない。
+	// ここで partial にすると最初の週・月に誤った注意書きが出る。
+	baseline := &battleBaselineDoc{
+		WeekKey: "2026-07-13",
+		Week:    map[string]int64{"a": 10},
+	}
+	closings := detectClosings(baseline, []rankingUpdateUserDoc{newUser("a", 20)}, "2026-07-20", "2026-07")
+	if len(closings) != 1 || closings[0].Partial {
+		t.Errorf("base_at が無いだけで partial にしてはいけない: %+v", closings)
+	}
+}
+
 func TestBaselineDeltas_SkipsUsersWithoutBaseline(t *testing.T) {
 	// 期間の途中から参加したユーザーは差分を出せないので載せない
 	// (現在値まるごとで1位になる事故を防ぐ)。


### PR DESCRIPTION
#222 で入れた `partial` 判定の誤り。

`base_at`(基準値を作った時刻)は締め機能と同時に足したフィールドだが、期間ランキング自体は #212 から動いている。既存の基準値ドキュメントはこのフィールドを持たないため、ゼロ値を「途中から集計を始めた」と見なすと、頭から記録できている最初の週・月に赤い注意書きが出てしまう。

ゼロ値は「フィールドを持つ前に作られた基準値」であって途中開始ではないので、partial としない。

実害の出る期間:

- 週 2026-07-27(8/3 0:00 の締め)— #212 のデプロイ(7/25)より後に始まった週なので、実際は頭から記録できている
- 月 2026-08(9/1 の締め)— 同上

どちらも次のロールオーバーで `base_at` が入るため、以降の期間は元の判定でそのまま正しく動く。

回帰テストを追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_