### PR TITLE
締めに失敗した期間が二度と締められなくなるのを修正

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -175,7 +175,7 @@ jobs:
       # (既に存在すれば describe が成功するのでスキップする、冪等な実装)。
       - name: create Pub/Sub topics for scheduled Go functions
         run: |
-          for TOPIC in ranking-update-go ranking-cache-go status-cache-backfill-go scheduled-ogp-delete-go battle-log-backfill-go; do
+          for TOPIC in ranking-update-go ranking-cache-go status-cache-backfill-go scheduled-ogp-delete-go battle-log-backfill-go ranking-close-retry-go; do
             gcloud pubsub topics describe "$TOPIC" --project=d-shrine-dev \
               || gcloud pubsub topics create "$TOPIC" --project=d-shrine-dev
           done
@@ -313,6 +313,9 @@ jobs:
           # 定時実行は無い。ログ方式への移行時に手で1度だけ叩く(#226)
           deploy battleLogBackfillGo BattleLogBackfillGo \
             --trigger-topic=battle-log-backfill-go --memory=512Mi --timeout=540s
+          # 定時実行は無い。締めを取りこぼしたときに手で叩く(#226)
+          deploy rankingCloseRetryGo RankingCloseRetryGo \
+            --trigger-topic=ranking-close-retry-go --memory=512Mi --timeout=540s
           deploy statusCacheBackfillGo StatusCacheBackfillGo \
             --trigger-topic=status-cache-backfill-go --memory=512Mi --timeout=300s
           deploy scheduledOgpDeleteGo ScheduledOgpDeleteGo \

--- a/.github/workflows/kick-scheduled-function.yml
+++ b/.github/workflows/kick-scheduled-function.yml
@@ -33,6 +33,8 @@ on:
           - scheduled-ogp-delete-go
           # 定時実行の無い一度きりの処理。ログ方式への移行時に叩く(#226)
           - battle-log-backfill-go
+          # 締めを取りこぼしたときのやり直し(#226)
+          - ranking-close-retry-go
 
 jobs:
   kick:

--- a/.github/workflows/kick-scheduled-function.yml
+++ b/.github/workflows/kick-scheduled-function.yml
@@ -59,3 +59,21 @@ jobs:
             --project="$PROJECT" \
             --message='{"kick":"manual","source":"github-actions"}'
           echo "published to ${{ inputs.topic }} in $PROJECT"
+          echo "PROJECT=$PROJECT" >> "$GITHUB_ENV"
+
+      # publish は「メッセージを置いた」ことしか示さない。関数が実際に何をしたか
+      # (特に失敗した理由)はCloud Loggingにしか出ないため、ここで拾って
+      # Actionsのログに出す。これが無いと、キックしたのに結果が変わらないとき
+      # GCPコンソールを開くまで原因が分からない。
+      - name: Show function logs
+        run: |
+          set -eo pipefail
+          # トピック名(kebab)から関数名(camel)へ。ranking-update-go → rankingUpdateGo
+          FUNC=$(echo "${{ inputs.topic }}" | awk -F- '{printf "%s", $1; for(i=2;i<=NF;i++) printf "%s%s", toupper(substr($i,1,1)), substr($i,2)}')
+          echo "waiting for $FUNC to run..."
+          sleep 45
+          gcloud logging read \
+            "resource.type=cloud_run_revision AND resource.labels.service_name=$FUNC" \
+            --project="$PROJECT" --limit=50 --freshness=10m \
+            --format='value(timestamp, severity, textPayload)' \
+            | tac || echo "(ログを取得できませんでした)"

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: create Pub/Sub topics for scheduled Go functions
         run: |
-          for TOPIC in ranking-update-go ranking-cache-go status-cache-backfill-go scheduled-ogp-delete-go battle-log-backfill-go; do
+          for TOPIC in ranking-update-go ranking-cache-go status-cache-backfill-go scheduled-ogp-delete-go battle-log-backfill-go ranking-close-retry-go; do
             gcloud pubsub topics describe "$TOPIC" --project=d-shrine \
               || gcloud pubsub topics create "$TOPIC" --project=d-shrine
           done
@@ -259,6 +259,9 @@ jobs:
           # 定時実行は無い。ログ方式への移行時に手で1度だけ叩く(#226)
           deploy battleLogBackfillGo BattleLogBackfillGo \
             --trigger-topic=battle-log-backfill-go --memory=512Mi --timeout=540s
+          # 定時実行は無い。締めを取りこぼしたときに手で叩く(#226)
+          deploy rankingCloseRetryGo RankingCloseRetryGo \
+            --trigger-topic=ranking-close-retry-go --memory=512Mi --timeout=540s
           deploy statusCacheBackfillGo StatusCacheBackfillGo \
             --trigger-topic=status-cache-backfill-go --memory=512Mi --timeout=300s
           deploy scheduledOgpDeleteGo ScheduledOgpDeleteGo \

--- a/app/functions-go/ranking_close_retry.go
+++ b/app/functions-go/ranking_close_retry.go
@@ -1,0 +1,119 @@
+// 取りこぼした締めのやり直し(rankingCloseRetry)。
+//
+// 締めは期間キーの変化で検出するため、失敗したまま状態のキーが進んでしまうと
+// その期間は二度と締められない(この取りこぼしを起こさないよう、rankingUpdateGo
+// 側は失敗した期間のキーを据え置いて再試行するようにした)。
+//
+// 既に状態が進んでしまった期間を後から締め直すための手動実行。ログ方式では
+// 期間の値は範囲集計なので、いつ締めても結果は同じ。
+//
+// 冪等。既にアーカイブがある期間は触らない(称号の二重付与も起きない)。
+// 定時実行は無く、Pub/Sub トピック ranking-close-retry-go へ手で publish する
+// (.github/workflows/kick-scheduled-function.yml)。
+package gofunctions
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+func init() {
+	functions.CloudEvent("RankingCloseRetryGo", rankingCloseRetryHandler)
+}
+
+func rankingCloseRetryHandler(ctx context.Context, _ cloudevents.Event) error {
+	client, err := getFirestoreClient(ctx)
+	if err != nil {
+		log.Printf("rankingCloseRetry: getFirestoreClient error: %v", err)
+		return err
+	}
+	return runRankingCloseRetry(ctx, client, time.Now())
+}
+
+// runRankingCloseRetry は「直前の週」を、まだアーカイブが無ければ締める。
+//
+// 月を対象にしないのは、獲得ログの無い過去の月まで締めると、ぽいんとだけが
+// 入ったアーカイブができて実態と食い違うため。月の取りこぼしが起きた場合は
+// 対象期間を見て個別に判断する。
+func runRankingCloseRetry(ctx context.Context, client *firestore.Client, now time.Time) error {
+	weekStart, _, _, _ := periodBounds(now)
+	prevStart := weekStart.AddDate(0, 0, -7)
+	prevEnd := weekStart
+	periodKey := prevStart.Format("2006-01-02")
+
+	exists, err := archiveExists(ctx, client, "week", periodKey)
+	if err != nil {
+		return err
+	}
+	if exists {
+		log.Printf("rankingCloseRetry: week %s は既に締め済み。何もしない", periodKey)
+		return nil
+	}
+
+	profiles, err := loadRankingProfiles(ctx, client)
+	if err != nil {
+		return err
+	}
+	if err := closePeriod(ctx, client, "week", periodKey, prevStart, prevEnd, profiles); err != nil {
+		return err
+	}
+	log.Printf("rankingCloseRetry: week %s を締めた(%v 〜 %v)", periodKey, prevStart, prevEnd)
+	return nil
+}
+
+// archiveExists はその期間のアーカイブが既にあるかを返す。
+func archiveExists(ctx context.Context, client *firestore.Client, periodType, periodKey string) (bool, error) {
+	_, err := client.Collection("ranking_archive").Doc(archiveDocID(periodType, periodKey)).Get(ctx)
+	if err != nil {
+		if grpcstatus.Code(err) == codes.NotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// loadRankingProfiles は全ユーザーの表示情報を読む。
+//
+// rankingUpdateGo は status.total / exp の降順クエリで得たユーザーから作るが、
+// ここではそれらのフィールドを持たないユーザーも取りこぼしたくないので全件見る
+// (手動実行なので読み取り量は問題にならない)。
+func loadRankingProfiles(ctx context.Context, client *firestore.Client) (map[string]rankingProfile, error) {
+	iter := client.Collection("users").Documents(ctx)
+	defer iter.Stop()
+
+	profiles := map[string]rankingProfile{}
+	for {
+		doc, err := iter.Next()
+		if err == iterator.Done {
+			return profiles, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		var u struct {
+			DisplayName string `firestore:"display_name"`
+			ScreenName  string `firestore:"screen_name"`
+			ImagePath   string `firestore:"image_path"`
+		}
+		if err := doc.DataTo(&u); err != nil {
+			// 想定外の形のユーザーで全体を止めない。
+			log.Printf("rankingCloseRetry: skip profile %s: %v", doc.Ref.ID, err)
+			continue
+		}
+		profiles[doc.Ref.ID] = rankingProfile{
+			DisplayName: u.DisplayName,
+			ScreenName:  u.ScreenName,
+			ImagePath:   u.ImagePath,
+		}
+	}
+}

--- a/app/functions-go/ranking_close_retry_test.go
+++ b/app/functions-go/ranking_close_retry_test.go
@@ -1,0 +1,81 @@
+package gofunctions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/firestore"
+)
+
+func TestRunRankingCloseRetry_ClosesPreviousWeekAndIsIdempotent(t *testing.T) {
+	client := emulatorClient(t)
+	ctx := context.Background()
+
+	// 2026-08-03(月)の 2:00 に実行 → 直前の週は 2026-07-27 〜 2026-08-02。
+	now := time.Date(2026, 8, 3, 2, 0, 0, 0, jst)
+	prevStart := time.Date(2026, 7, 27, 0, 0, 0, 0, jst)
+
+	prefix := "TestCloseRetry_"
+	seed := func(collection, id string, point int64, at time.Time) {
+		userRef := client.Collection("users").Doc(prefix + id)
+		if _, err := userRef.Set(ctx, map[string]interface{}{
+			"display_name": "name" + id, "screen_name": "screen" + id,
+		}, firestore.MergeAll); err != nil {
+			t.Fatalf("seed user: %v", err)
+		}
+		if _, _, err := userRef.Collection(collection).Add(ctx, map[string]interface{}{
+			"add_point": point, "timestamp": at,
+		}); err != nil {
+			t.Fatalf("seed %s: %v", collection, err)
+		}
+	}
+	seed(battleLogsCollection, "a", 700, prevStart.Add(30*time.Hour))
+	seed(battleLogsCollection, "b", 40, prevStart.Add(31*time.Hour))
+	seed("sanpai_logs", "a", 15, prevStart.Add(30*time.Hour))
+	// 締める週の外(新しい週)。確定値に入ってはいけない。
+	seed(battleLogsCollection, "a", 9999, now)
+
+	if err := runRankingCloseRetry(ctx, client, now); err != nil {
+		t.Fatalf("runRankingCloseRetry: %v", err)
+	}
+
+	snap, err := client.Collection("ranking_archive").Doc("week_2026-07-27").Get(ctx)
+	if err != nil {
+		t.Fatalf("アーカイブが作られていない: %v", err)
+	}
+	var doc rankingArchiveDoc
+	if err := snap.DataTo(&doc); err != nil {
+		t.Fatalf("DataTo: %v", err)
+	}
+	if len(doc.BattleTop) < 2 || doc.BattleTop[0].ScreenName != "screena" || doc.BattleTop[0].Value != 700 {
+		t.Fatalf("せんとうりょくの確定順位が違う(週外の9999が混ざっていないか): %+v", doc.BattleTop)
+	}
+	if len(doc.PointsTop) < 1 || doc.PointsTop[0].ScreenName != "screena" {
+		t.Errorf("ぽいんとの確定順位が違う: %+v", doc.PointsTop)
+	}
+
+	crownCount := func() int64 {
+		s, err := client.Collection("users").Doc(prefix + "a").Get(ctx)
+		if err != nil {
+			t.Fatalf("get user: %v", err)
+		}
+		v, err := s.DataAt("crowns.week_battle_first.count")
+		if err != nil {
+			t.Fatalf("称号が付いていない: %v", err)
+		}
+		n, _ := v.(int64)
+		return n
+	}
+	if got := crownCount(); got != 1 {
+		t.Errorf("称号の回数 = %d, want 1", got)
+	}
+
+	// 2度目は既にアーカイブがあるので何もしない(称号も増えない)。
+	if err := runRankingCloseRetry(ctx, client, now); err != nil {
+		t.Fatalf("runRankingCloseRetry 2: %v", err)
+	}
+	if got := crownCount(); got != 1 {
+		t.Errorf("2度目で称号が増えてはいけない: %d", got)
+	}
+}

--- a/app/functions-go/ranking_update.go
+++ b/app/functions-go/ranking_update.go
@@ -134,18 +134,27 @@ func appendPeriodRankings(ctx context.Context, client *firestore.Client, data ma
 	}
 
 	// 期間が変わっていたら閉じた期間を確定させる。締めは間引きに関係なく走る。
+	//
+	// 締めに失敗した期間はキーを進めない。進めてしまうと次の実行では期間の
+	// 変化が検出されず、その期間は二度と締められなくなる。据え置けば次の実行で
+	// 自動的に再試行される(値はログの範囲集計なので、いつ締めても同じ結果)。
 	closings := detectClosings(state, weekKey, monthKey)
+	failed := make(map[string]bool, len(closings))
 	for _, c := range closings {
 		if err := closePeriod(ctx, client, c.Type, c.Key, c.Start, c.End, profiles); err != nil {
-			// 締めに失敗しても状態の更新は続ける。ここで止めると毎時同じ期間の
-			// 締めを試み続けることになるため(ログは範囲集計なので、後から手で
-			// 締め直せる)。
-			log.Printf("rankingUpdate: close %s %s failed: %v", c.Type, c.Key, err)
+			log.Printf("rankingUpdate: close %s %s failed (次の実行で再試行): %v", c.Type, c.Key, err)
+			failed[c.Type] = true
 		}
 	}
-	if len(closings) > 0 || state.WeekKey != weekKey || state.MonthKey != monthKey {
-		state.WeekKey, state.MonthKey = weekKey, monthKey
-		if err := savePeriodState(ctx, client, state); err != nil {
+	next := *state
+	if !failed["week"] {
+		next.WeekKey = weekKey
+	}
+	if !failed["month"] {
+		next.MonthKey = monthKey
+	}
+	if next != *state {
+		if err := savePeriodState(ctx, client, &next); err != nil {
 			return err
 		}
 	}

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -727,6 +727,16 @@ kudaがAPIキー認証を導入(移行期間中は `REQUIRE_API_KEY=0` でキー
 - 定時実行は無い。Pub/Sub トピック `battle-log-backfill-go` へ手で publish する
   (`.github/workflows/kick-scheduled-function.yml`)
 
+### 締めを取りこぼさない
+
+締めは期間キーの変化で検出するため、**失敗したまま状態のキーを進めると、その
+期間は二度と締められない**。そこで失敗した期間はキーを据え置き、次の実行で
+自動的に再試行する(値はログの範囲集計なので、いつ締めても結果は同じ)。
+
+既にキーが進んでしまった期間を後から締め直すために `rankingCloseRetryGo`
+(Pub/Sub トピック `ranking-close-retry-go`、定時実行なし)を用意している。
+直前の週にアーカイブが無ければ締める。既にあれば何もしないので冪等。
+
 ### 実行頻度
 
 `rankingUpdateGo`(毎時)に相乗りする。usersの全件スキャンは既存のものを


### PR DESCRIPTION
本番の最初の締め(8/3 0:00 JST)が取りこぼされ、`/ranking/history` が空のままになった。

## 原因

締めは期間キーの変化(`ranking_period_state` の `week_key` / `month_key`)で検出する。しかし締めが失敗しても状態のキーを進めていたため、次の実行では期間の変化が検出されず、**その期間は二度と締められない**。

```go
// 修正前: 失敗しても進めていた
for _, c := range closings {
    if err := closePeriod(...); err != nil {
        log.Printf(...)   // ログを出すだけ
    }
}
state.WeekKey, state.MonthKey = weekKey, monthKey  // ← 失敗した期間も進む
```

「後から手で締め直せる」というコメントを書いておきながら、締め直す手段を用意していなかった。

## 修正

### 1. 失敗した期間はキーを据え置く

次の実行で自動的に再試行される。値はログの範囲集計なので、いつ締めても結果は同じ。

### 2. `rankingCloseRetryGo` を追加

既にキーが進んでしまった期間を後から締め直すための手動実行(Pub/Sub トピック `ranking-close-retry-go`、定時実行なし)。直前の週にアーカイブが無ければ締め、あれば何もしない。称号の二重付与も起きない。

月を対象にしないのは、獲得ログの無い過去の月まで締めると、ぽいんとだけが入ったアーカイブができて実態と食い違うため。月の取りこぼしが起きた場合は対象期間を見て個別に判断する。

## 確認したこと

- エミュレータで `go vet ./...` / `go test ./...` 全パス
- 追加したテスト: 直前の週を締めること、締める週の外のログが確定値に入らないこと、1位に称号が付くこと、2度目の実行で何も起きない(称号が増えない)こと

## 反映後の手順

デプロイ後に `ranking-close-retry-go` を1度キックして、7/27〜8/2 の週を締め直す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_