### PR TITLE
関数のログを見る手段を用意し、アーカイブ一覧の握り潰しをやめる

### DIFF
--- a/.github/workflows/show-function-logs.yml
+++ b/.github/workflows/show-function-logs.yml
@@ -1,0 +1,54 @@
+# Cloud Run functions のログを Actions のログに出す。
+#
+# HTTPエンドポイント(rankingArchiveGo 等)が期待どおり動かないとき、原因は
+# Cloud Logging にしか出ない。GCPコンソールを開かずに切り分けられるようにする。
+#
+# セキュリティ: workflow_dispatch はリポジトリのwrite権限を持つメンバーしか
+# 実行できない。読み取りのみで副作用は無い。
+name: Show function logs
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: '対象環境'
+        required: true
+        type: choice
+        options:
+          - dev
+          - prod
+      function:
+        description: '関数名(Cloud Run のサービス名。例: rankingArchiveGo)'
+        required: true
+        type: string
+      freshness:
+        description: 'さかのぼる時間(例: 30m, 2h)'
+        required: false
+        type: string
+        default: '30m'
+
+jobs:
+  logs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: ${{ inputs.environment == 'prod' && secrets.PROD_GCLOUD_SERVICE_KEY || secrets.DEV_GCLOUD_SERVICE_KEY }}
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: Read logs
+        run: |
+          set -eo pipefail
+          if [ "${{ inputs.environment }}" = "prod" ]; then
+            PROJECT=d-shrine
+          else
+            PROJECT=d-shrine-dev
+          fi
+          echo "=== ${{ inputs.function }} in $PROJECT (直近 ${{ inputs.freshness }}) ==="
+          gcloud logging read \
+            "resource.type=cloud_run_revision AND resource.labels.service_name=${{ inputs.function }}" \
+            --project="$PROJECT" --limit=100 --freshness="${{ inputs.freshness }}" \
+            --format='value(timestamp, severity, textPayload, jsonPayload.message)' \
+            | tac || echo "(ログを取得できませんでした)"

--- a/app/functions-go/ranking_archive_api.go
+++ b/app/functions-go/ranking_archive_api.go
@@ -135,6 +135,9 @@ func loadArchiveList(ctx context.Context, client *firestore.Client, periodType s
 		}
 		var d rankingArchiveDoc
 		if err := doc.DataTo(&d); err != nil {
+			// 1件の形が想定外でも一覧全体は返す。ただし黙って消すと
+			// 「締めたのに履歴に出ない」の原因が分からなくなるので必ず残す。
+			log.Printf("rankingArchive: skip %s: %v", doc.Ref.ID, err)
 			continue
 		}
 		resp.Periods = append(resp.Periods, archivePeriodSummary{


### PR DESCRIPTION
本番で締めは成功していた(`rankingCloseRetry: week 2026-07-27 は既に締め済み`)のに、履歴ページには何も出ない。原因の切り分けに必要なものが2つ足りなかった。

## 1. 関数のログを見る手段

HTTPエンドポイント(`rankingArchiveGo` 等)が期待どおり動かないとき、原因は Cloud Logging にしか出ない。GCPコンソールを開かずに切り分けられるよう、関数名を指定してログを Actions のログに出す workflow を追加する。読み取りのみで副作用は無い。

## 2. アーカイブ一覧の握り潰し

`loadArchiveList` はドキュメントのデコードに失敗すると黙って `continue` していた。そのため「1件も無い」と「全件デコードに失敗した」が区別できない。失敗をログに残す。

一覧全体を落とさない方針は変えない(1件の形が想定外でも他は返したい)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_