### PR TITLE
空の過去ランキング一覧を長時間キャッシュしないようにする

### DIFF
--- a/.github/workflows/show-function-logs.yml
+++ b/.github/workflows/show-function-logs.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: '30m'
+      probe_url:
+        description: '先に叩いて応答を見るURL(任意)'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   logs:
@@ -37,6 +42,20 @@ jobs:
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
+
+      # 「関数にリクエストが届いていない」ときは、どこで止まっているかを
+      # 実際に叩いて確かめるのが早い(Hosting のrewriteが効いていない、
+      # SPAのHTMLが返っている、等はここで一目で分かる)。
+      - name: Probe URL
+        if: inputs.probe_url != ''
+        run: |
+          set -eo pipefail
+          echo "=== GET ${{ inputs.probe_url }} ==="
+          curl -sS -D - -o /tmp/body "${{ inputs.probe_url }}" | head -20
+          echo "--- body (先頭400文字) ---"
+          head -c 400 /tmp/body
+          echo
+          echo "--- body size: $(wc -c < /tmp/body) bytes ---"
 
       - name: Read logs
         run: |

--- a/.github/workflows/show-function-logs.yml
+++ b/.github/workflows/show-function-logs.yml
@@ -47,8 +47,11 @@ jobs:
             PROJECT=d-shrine-dev
           fi
           echo "=== ${{ inputs.function }} in $PROJECT (直近 ${{ inputs.freshness }}) ==="
+          # Cloud Run のログは、アプリの出力(textPayload)とリクエストログ
+          # (httpRequest)が混ざる。4xx/5xx はリクエストログ側にしか出ないので
+          # ステータスとURLも必ず出す。
           gcloud logging read \
             "resource.type=cloud_run_revision AND resource.labels.service_name=${{ inputs.function }}" \
             --project="$PROJECT" --limit=100 --freshness="${{ inputs.freshness }}" \
-            --format='value(timestamp, severity, textPayload, jsonPayload.message)' \
+            --format='value(timestamp, severity, httpRequest.status, httpRequest.requestMethod, httpRequest.requestUrl, textPayload, jsonPayload.message, protoPayload.status.message)' \
             | tac || echo "(ログを取得できませんでした)"

--- a/app/functions-go/ranking_archive_api.go
+++ b/app/functions-go/ranking_archive_api.go
@@ -92,14 +92,27 @@ func rankingArchiveHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Cache-Control", "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400")
 	resp, err := loadArchiveList(ctx, client, periodType, archiveListLimit(r))
 	if err != nil {
 		log.Printf("rankingArchive: loadArchiveList error: %v", err)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
+	w.Header().Set("Cache-Control", archiveListCacheControl(len(resp.Periods)))
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// archiveListCacheControl は一覧のキャッシュ指定を返す(純関数)。
+//
+// 空の一覧は「まだ1件も締めていない」という一時的な状態で、次の締めで必ず
+// 変わる。これを長く持たせると、締めが成功しても画面が空のまま居座る
+// (実際、機能の投入直後に空をキャッシュしてしまい、締めた後も履歴ページが
+// 空に見え続けた)。空のときは短く、1件でもあるときだけ長く持たせる。
+func archiveListCacheControl(count int) string {
+	if count == 0 {
+		return "public, max-age=30, s-maxage=30"
+	}
+	return "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400"
 }
 
 // archiveListLimit は ?limit= を読み取る(範囲外・不正は既定値)。

--- a/app/functions-go/ranking_archive_api_cache_test.go
+++ b/app/functions-go/ranking_archive_api_cache_test.go
@@ -1,0 +1,15 @@
+package gofunctions
+
+import "testing"
+
+func TestArchiveListCacheControl(t *testing.T) {
+	// 空は一時的な状態。長く持たせると締めた後も空のまま居座る。
+	if got := archiveListCacheControl(0); got != "public, max-age=30, s-maxage=30" {
+		t.Errorf("空の一覧は短命であるべき: %q", got)
+	}
+	// 1件でもあれば、締め済みの内容は変わらないので長く持たせてよい。
+	got := archiveListCacheControl(1)
+	if got == archiveListCacheControl(0) {
+		t.Errorf("件数があるときは長いキャッシュにするべき: %q", got)
+	}
+}


### PR DESCRIPTION
## 何が起きたか

本番で 8/3 0:00 JST の締めは成功し、`ranking_archive/week_2026-07-27` も保存され、API も正しく返していた。

```
$ curl 'https://d-shrine.jp/rankingArchiveGo?type=week'
{"periods":[{"period_type":"week","period_key":"2026-07-27","label":"2026/7/27 〜 8/2"}]}
```

にもかかわらず履歴ページは空のままだった。関数のログを見ると、**ブラウザからのリクエストが1件も届いていない**。CDN が返していた。

## 原因

一覧を `s-maxage=3600, stale-while-revalidate=86400` で配信していた。締めより前(機能を投入した直後)に誰かが履歴ページを開くと、その時点の**空のレスポンスがエッジに最大24時間居座る**。締めが成功しても画面は空のまま、という状態になる。

## 修正

空の一覧は「まだ1件も締めていない」という一時的な状態で、次の締めで必ず変わる。そのときだけ 30 秒に短縮する。1件でもあれば締め済みの内容は変わらないので従来どおり長く持たせる。

## 確認したこと

- `go vet ./...` / `go test ./...` パス
- 純関数として切り出してテストを追加(空は短命、件数があれば長命)

## 補足

この一連の切り分けで入れた `show-function-logs` workflow(#230)と、キック結果をログに出す仕組み(#229)が無ければ、CDN が返していることに辿り着けなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_