### PR TITLE
未作成の期間の404を長時間キャッシュしないようにする

### DIFF
--- a/app/functions-go/ranking_archive_api.go
+++ b/app/functions-go/ranking_archive_api.go
@@ -77,13 +77,14 @@ func rankingArchiveHandler(w http.ResponseWriter, r *http.Request) {
 	// 締め済みの内容は変わらないので、共有キャッシュに長く置く。
 	// 一覧は新しい期間が増えるため、詳細より短くしておく。
 	if period := r.URL.Query().Get("period"); period != "" {
-		w.Header().Set("Cache-Control", "public, max-age=600, s-maxage=86400, stale-while-revalidate=86400")
 		resp, err := loadArchiveDetail(ctx, client, periodType, period)
 		if err != nil {
 			log.Printf("rankingArchive: loadArchiveDetail error: %v", err)
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
+		// キャッシュ指定は中身が分かってから。見つかったかどうかで長さが違う。
+		w.Header().Set("Cache-Control", archiveDetailCacheControl(resp != nil))
 		if resp == nil {
 			writeError(w, http.StatusNotFound, "period not found")
 			return
@@ -100,6 +101,20 @@ func rankingArchiveHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Cache-Control", archiveListCacheControl(len(resp.Periods)))
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// archiveDetailCacheControl は詳細のキャッシュ指定を返す(純関数)。
+//
+// 締め済みの内容は変わらないので長く置いてよいが、「まだ無い」は一時的な状態で、
+// 締めれば必ず変わる。以前は中身を見る前にヘッダを立てていたため、未作成の期間を
+// 引いた 404 が s-maxage=86400 で共有キャッシュに載り、後から締めても丸一日
+// 「無い」と返り続ける状態になっていた(2026-07 を遡って作ったときに踏んだ)。
+// 一覧が空のときと同じ扱いにする。
+func archiveDetailCacheControl(found bool) string {
+	if !found {
+		return "public, max-age=30, s-maxage=30"
+	}
+	return "public, max-age=600, s-maxage=86400, stale-while-revalidate=86400"
 }
 
 // archiveListCacheControl は一覧のキャッシュ指定を返す(純関数)。

--- a/app/functions-go/ranking_archive_api_cache_test.go
+++ b/app/functions-go/ranking_archive_api_cache_test.go
@@ -13,3 +13,14 @@ func TestArchiveListCacheControl(t *testing.T) {
 		t.Errorf("件数があるときは長いキャッシュにするべき: %q", got)
 	}
 }
+
+func TestArchiveDetailCacheControl(t *testing.T) {
+	// 「まだ無い」は一時的な状態。長く持たせると、後から締めても
+	// 共有キャッシュが丸一日 404 を返し続ける。
+	if got := archiveDetailCacheControl(false); got != "public, max-age=30, s-maxage=30" {
+		t.Errorf("未作成の期間は短命であるべき: %q", got)
+	}
+	if got := archiveDetailCacheControl(true); got == archiveDetailCacheControl(false) {
+		t.Errorf("締め済みは長いキャッシュにするべき: %q", got)
+	}
+}


### PR DESCRIPTION
## 背景

`rankingArchiveGo` の詳細取得で、キャッシュ指定を**中身を見る前に**立てていた。

```go
w.Header().Set("Cache-Control", "public, max-age=600, s-maxage=86400, ...")
resp, err := loadArchiveDetail(...)
...
if resp == nil {
    writeError(w, http.StatusNotFound, "period not found")  // ← 404 も同じヘッダで返る
    return
}
```

そのためまだ締めていない期間を引いた 404 が `s-maxage=86400` で共有キャッシュに載り、
**後から締めても丸一日「無い」と返り続ける**。

2026-07 を遡って作ったときに実際に踏んでいる。復元中に何度か確認のため叩いており、
その 404 が Fastly の POP に残っている:

```
HTTP/2 404
cache-control: public, max-age=600, s-maxage=86400, stale-while-revalidate=86400
{"message":"period not found","status":"failed"}
```

一覧が空のときに同じことが起きた（#231）のと同じ種類の穴。あちらだけ直して、
詳細側が残っていた。

## 変更

`archiveDetailCacheControl(found bool)` を切り出し、キャッシュ指定は
`loadArchiveDetail` の結果が分かってから立てる。見つからなかったときは
一覧の空と同じく30秒。

## テスト

`TestArchiveDetailCacheControl` を追加（未作成は短命／締め済みは長命）。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01DwkB6Hj2JggoKcy7FoxNcU)_